### PR TITLE
Refactor auth and user logic into service layer

### DIFF
--- a/rate-pulse-api/api/errors.go
+++ b/rate-pulse-api/api/errors.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/ThanhVinhTong/rate-pulse/service"
+	"github.com/gin-gonic/gin"
+)
+
+func RespondServiceError(ctx *gin.Context, err error) {
+	switch service.ServiceErrorCode(err) {
+	case service.ErrInvalidInput.Code:
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+	case service.ErrInvalidCredentials.Code,
+		service.ErrUnauthorized.Code,
+		service.ErrSessionNotFound.Code,
+		service.ErrSessionBlocked.Code,
+		service.ErrSessionExpired.Code:
+		ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+	case service.ErrDuplicateEmail.Code:
+		ctx.JSON(http.StatusConflict, errorResponse(err))
+	default:
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+	}
+}

--- a/rate-pulse-api/api/server.go
+++ b/rate-pulse-api/api/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/service"
 	"github.com/ThanhVinhTong/rate-pulse/token"
 	"github.com/ThanhVinhTong/rate-pulse/util"
 	"github.com/gin-contrib/cors"
@@ -17,6 +18,7 @@ type Server struct {
 	config     util.Config
 	store      *db.Store
 	tokenMaker token.Maker
+	services   *service.Services
 	router     *gin.Engine
 }
 
@@ -30,6 +32,7 @@ func NewServer(config util.Config, store *db.Store) (*Server, error) {
 		config:     config,
 		store:      store,
 		tokenMaker: tokenMaker,
+		services:   service.NewServices(config, store, tokenMaker),
 	}
 
 	server.setupRouter()

--- a/rate-pulse-api/api/token.go
+++ b/rate-pulse-api/api/token.go
@@ -1,11 +1,10 @@
 package api
 
 import (
-	"database/sql"
-	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/ThanhVinhTong/rate-pulse/service"
 	"github.com/gin-gonic/gin"
 )
 
@@ -25,60 +24,16 @@ func (server *Server) renewAccessToken(ctx *gin.Context) {
 		return
 	}
 
-	refreshPayload, err := server.tokenMaker.VerifyToken(req.RefreshToken)
+	res, err := server.services.Auth.RenewAccessToken(ctx, service.RenewAccessTokenInput{
+		RefreshToken: req.RefreshToken,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
-	session, err := server.store.GetSessionByID(ctx, refreshPayload.ID)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "session not found"})
-			return
-		}
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	if session.IsBlocked.Valid && session.IsBlocked.Bool {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "session is blocked"})
-		return
-	}
-
-	if session.UserID != refreshPayload.UserID {
-		err := fmt.Errorf("incorrect session user")
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-		return
-	}
-
-	if session.RefreshToken != req.RefreshToken {
-		err := fmt.Errorf("mismatched session token")
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-		return
-	}
-
-	if time.Now().After(session.ExpiresAt) {
-		err := fmt.Errorf("session expired")
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-		return
-	}
-
-	accessToken, accessPayload, err := server.tokenMaker.CreateToken(
-		refreshPayload.UserID,
-		refreshPayload.Username,
-		refreshPayload.Email,
-		refreshPayload.UserType,
-		server.config.AccessTokenDuration,
-	)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	res := renewAccessTokenResponse{
-		AccessToken:          accessToken,
-		AccessTokenExpiresAt: accessPayload.ExpiredAt,
-	}
-	ctx.JSON(http.StatusOK, res)
+	ctx.JSON(http.StatusOK, renewAccessTokenResponse{
+		AccessToken:          res.AccessToken,
+		AccessTokenExpiresAt: res.AccessTokenExpiresAt,
+	})
 }

--- a/rate-pulse-api/api/user.go
+++ b/rate-pulse-api/api/user.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/service"
 	"github.com/ThanhVinhTong/rate-pulse/util"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 )
 
 // createUserRequest represents the request body for creating a new user.
@@ -71,6 +71,26 @@ func newUserResponse(user db.User) userResponse {
 	}
 }
 
+// mapper from AuthUser to userResponse
+func newUserResponseFromAuthUser(user service.AuthUser) userResponse {
+	return userResponse{
+		UserID:             user.UserID,
+		Username:           user.Username,
+		Email:              user.Email,
+		UserType:           user.UserType,
+		EmailVerified:      user.EmailVerified,
+		TimeZone:           user.TimeZone,
+		LanguagePreference: user.LanguagePreference,
+		CountryOfResidence: user.CountryOfResidence,
+		CountryOfBirth:     user.CountryOfBirth,
+		FirstName:          user.FirstName,
+		LastName:           user.LastName,
+		IsActive:           user.IsActive,
+		CreatedAt:          user.CreatedAt,
+		UpdatedAt:          user.UpdatedAt,
+	}
+}
+
 // createUser handles the creation of a new user.
 // It binds the JSON request body to createUserRequest, validates the input,
 // and persists the user to the database.
@@ -90,52 +110,23 @@ func (server *Server) createUser(ctx *gin.Context) {
 		return
 	}
 
-	// Normalize the email address
-	req.Email = util.NormalizeEmail(req.Email)
-
-	// Check if the password is weak or not
-	if err := util.ValidatePassword(req.Password); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Hash the password before storing
-	hashedPassword, err := util.HashPassword(req.Password)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	arg := db.CreateUserParams{
+	user, err := server.services.Auth.CreateUser(ctx, service.CreateUserInput{
 		Username:           req.Username,
 		Email:              req.Email,
-		Password:           hashedPassword,
-		UserType:           sql.NullString{String: UserTypeFree, Valid: true},
-		EmailVerified:      sql.NullBool{Bool: false, Valid: true},
-		TimeZone:           sql.NullString{String: req.TimeZone, Valid: true},
-		LanguagePreference: sql.NullString{String: req.LanguagePreference, Valid: true},
-		CountryOfResidence: sql.NullString{String: req.CountryOfResidence, Valid: true},
-		CountryOfBirth:     sql.NullString{String: req.CountryOfBirth, Valid: true},
-		IsActive:           sql.NullBool{Bool: true, Valid: true},
-		LastName:           sql.NullString{String: req.LastName, Valid: true},
-		FirstName:          sql.NullString{String: req.FirstName, Valid: true},
-	}
-
-	user, err := server.store.CreateUser(ctx, arg)
+		Password:           req.Password,
+		TimeZone:           req.TimeZone,
+		LanguagePreference: req.LanguagePreference,
+		CountryOfResidence: req.CountryOfResidence,
+		CountryOfBirth:     req.CountryOfBirth,
+		FirstName:          req.FirstName,
+		LastName:           req.LastName,
+	})
 	if err != nil {
-		// handle unique violation error
-		if pqErr, ok := err.(*pq.Error); ok {
-			switch pqErr.Code.Name() {
-			case "unique_violation":
-				ctx.JSON(http.StatusForbidden, errorResponse(err))
-				return
-			}
-		}
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, newUserResponse(user))
+	ctx.JSON(http.StatusOK, newUserResponseFromAuthUser(user))
 }
 
 // getUserRequest represents the URI parameters for fetching a single user.
@@ -429,94 +420,24 @@ func (server *Server) loginUser(ctx *gin.Context) {
 		return
 	}
 
-	const invalidCredentialsMsg = "invalid email or password"
-
-	/// Early validation to prevent hitting database on bad input
-	if req.Email == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "email is required"})
-		return
-	}
-	if len(req.Email) > 254 {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "email is too long"})
-		return
-	}
-	if req.Password == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "password is required"})
-		return
-	}
-
-	// Normalize the email address
-	req.Email = util.NormalizeEmail(req.Email)
-
-	user, err := server.store.GetUserByEmail(ctx, req.Email)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			ctx.JSON(http.StatusUnauthorized, gin.H{"error": invalidCredentialsMsg})
-			return
-		}
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	if err := util.CheckPassword(req.Password, user.Password); err != nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": invalidCredentialsMsg})
-		return
-	}
-
-	// Check if the user is email verified
-	// TODO: Implement this check after finishing email verification
-
-	// Check if the user is active
-	if user.IsActive.Valid && !user.IsActive.Bool {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": invalidCredentialsMsg})
-		return
-	}
-
-	accessToken, accessPayload, err := server.tokenMaker.CreateToken(
-		user.UserID,
-		user.Username,
-		user.Email,
-		user.UserType.String,
-		server.config.AccessTokenDuration,
-	)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	refreshToken, refreshPayload, err := server.tokenMaker.CreateToken(
-		user.UserID,
-		user.Username,
-		user.Email,
-		user.UserType.String,
-		server.config.RefreshTokenDuration,
-	)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return
-	}
-
-	session, err := server.store.CreateSession(ctx, db.CreateSessionParams{
-		SessionID:    refreshPayload.ID,
-		UserID:       user.UserID,
-		RefreshToken: refreshToken,
-		UserAgent:    ctx.Request.UserAgent(),
-		ClientIp:     ctx.ClientIP(),
-		IsBlocked:    sql.NullBool{Bool: false, Valid: true},
-		ExpiresAt:    refreshPayload.ExpiredAt,
+	args, err := server.services.Auth.SignIn(ctx, service.SignInInput{
+		Email:     req.Email,
+		Password:  req.Password,
+		UserAgent: ctx.Request.UserAgent(),
+		ClientIP:  ctx.ClientIP(),
 	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
 	res := loginUserResponse{
-		SessionID:             session.SessionID,
-		AccessToken:           accessToken,
-		AccessTokenExpiresAt:  accessPayload.ExpiredAt,
-		RefreshToken:          refreshToken,
-		RefreshTokenExpiresAt: refreshPayload.ExpiredAt,
-		User:                  newUserResponse(user),
+		SessionID:             args.SessionID,
+		AccessToken:           args.AccessToken,
+		AccessTokenExpiresAt:  args.AccessTokenExpiresAt,
+		RefreshToken:          args.RefreshToken,
+		RefreshTokenExpiresAt: args.RefreshTokenExpiresAt,
+		User:                  newUserResponseFromAuthUser(args.User),
 	}
 	ctx.JSON(http.StatusOK, res)
 }
@@ -530,9 +451,11 @@ func (server *Server) logoutUser(ctx *gin.Context) {
 		return
 	}
 
-	// For now, we'll just return success.
-	// Later you can add logic to mark the session as blocked using the refresh token.
-	ctx.JSON(http.StatusOK, gin.H{
-		"message": "Successfully signed out",
-	})
+	err := server.services.Auth.SignOut(ctx, req.RefreshToken)
+	if err != nil {
+		RespondServiceError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "Successfully signed out"})
 }

--- a/rate-pulse-api/api/user.go
+++ b/rate-pulse-api/api/user.go
@@ -1,13 +1,11 @@
 package api
 
 import (
-	"database/sql"
 	"net/http"
 	"time"
 
 	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
 	"github.com/ThanhVinhTong/rate-pulse/service"
-	"github.com/ThanhVinhTong/rate-pulse/util"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -71,8 +69,8 @@ func newUserResponse(user db.User) userResponse {
 	}
 }
 
-// mapper from AuthUser to userResponse
-func newUserResponseFromAuthUser(user service.AuthUser) userResponse {
+// mapper from User to userResponse
+func newUserResponseFromServiceUser(user service.User) userResponse {
 	return userResponse{
 		UserID:             user.UserID,
 		Username:           user.Username,
@@ -126,7 +124,7 @@ func (server *Server) createUser(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, newUserResponseFromAuthUser(user))
+	ctx.JSON(http.StatusOK, newUserResponseFromServiceUser(user))
 }
 
 // getUserRequest represents the URI parameters for fetching a single user.
@@ -155,13 +153,15 @@ func (server *Server) getUser(ctx *gin.Context) {
 		return
 	}
 
-	user, err := server.store.GetUserByID(ctx, req.ID)
+	user, err := server.services.Users.GetUser(ctx, service.GetUserInput{
+		UserID: req.ID,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, newUserResponse(user))
+	ctx.JSON(http.StatusOK, newUserResponseFromServiceUser(user))
 }
 
 // listUserRequest represents the query parameters for listing users with pagination.
@@ -192,20 +192,18 @@ func (server *Server) listUser(ctx *gin.Context) {
 		return
 	}
 
-	arg := db.ListUsersParams{
-		Limit:  req.PageSize,
-		Offset: (req.PageID - 1) * req.PageSize,
-	}
-
-	users, err := server.store.ListUsers(ctx, arg)
+	users, err := server.services.Users.ListUsers(ctx, service.ListUsersInput{
+		PageID:   req.PageID,
+		PageSize: req.PageSize,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
 	responses := make([]userResponse, len(users))
 	for i, user := range users {
-		responses[i] = newUserResponse(user)
+		responses[i] = newUserResponseFromServiceUser(user)
 	}
 
 	ctx.JSON(http.StatusOK, responses)
@@ -270,37 +268,24 @@ func (server *Server) updateUser(ctx *gin.Context) {
 		return
 	}
 
-	// Hash password if provided
-	var hashedPassword *string
-	if req.Password != nil {
-		hashed, err := util.HashPassword(*req.Password)
-		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-			return
-		}
-		hashedPassword = &hashed
-	}
-
-	arg := db.UpdateUserParams{
-		Username:           sql.NullString{String: util.Value(req.Username), Valid: req.Username != nil},
-		Email:              sql.NullString{String: util.Value(req.Email), Valid: req.Email != nil},
-		Password:           sql.NullString{String: util.Value(hashedPassword), Valid: hashedPassword != nil},
-		TimeZone:           sql.NullString{String: util.Value(req.TimeZone), Valid: req.TimeZone != nil},
-		LanguagePreference: sql.NullString{String: util.Value(req.LanguagePreference), Valid: req.LanguagePreference != nil},
-		CountryOfResidence: sql.NullString{String: util.Value(req.CountryOfResidence), Valid: req.CountryOfResidence != nil},
-		CountryOfBirth:     sql.NullString{String: util.Value(req.CountryOfBirth), Valid: req.CountryOfBirth != nil},
-		FirstName:          sql.NullString{String: util.Value(req.FirstName), Valid: req.FirstName != nil},
-		LastName:           sql.NullString{String: util.Value(req.LastName), Valid: req.LastName != nil},
+	user, err := server.services.Users.UpdateUser(ctx, service.UpdateUserInput{
 		UserID:             uriReq.ID,
-	}
-
-	user, err := server.store.UpdateUser(ctx, arg)
+		Username:           req.Username,
+		Email:              req.Email,
+		Password:           req.Password,
+		TimeZone:           req.TimeZone,
+		LanguagePreference: req.LanguagePreference,
+		CountryOfResidence: req.CountryOfResidence,
+		CountryOfBirth:     req.CountryOfBirth,
+		FirstName:          req.FirstName,
+		LastName:           req.LastName,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, newUserResponse(user))
+	ctx.JSON(http.StatusOK, newUserResponseFromServiceUser(user))
 }
 
 // adminUpdateUser handles admin-only updates to an existing user.
@@ -327,40 +312,27 @@ func (server *Server) adminUpdateUser(ctx *gin.Context) {
 		return
 	}
 
-	// Hash password if provided
-	var hashedPassword *string
-	if req.Password != nil {
-		hashed, err := util.HashPassword(*req.Password)
-		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-			return
-		}
-		hashedPassword = &hashed
-	}
-
-	arg := db.UpdateUserParams{
-		Username:           sql.NullString{String: util.Value(req.Username), Valid: req.Username != nil},
-		Email:              sql.NullString{String: util.Value(req.Email), Valid: req.Email != nil},
-		Password:           sql.NullString{String: util.Value(hashedPassword), Valid: hashedPassword != nil},
-		UserType:           sql.NullString{String: util.Value(req.UserType), Valid: req.UserType != nil},
-		EmailVerified:      sql.NullBool{Bool: util.Value(req.EmailVerified), Valid: req.EmailVerified != nil},
-		TimeZone:           sql.NullString{String: util.Value(req.TimeZone), Valid: req.TimeZone != nil},
-		LanguagePreference: sql.NullString{String: util.Value(req.LanguagePreference), Valid: req.LanguagePreference != nil},
-		CountryOfResidence: sql.NullString{String: util.Value(req.CountryOfResidence), Valid: req.CountryOfResidence != nil},
-		CountryOfBirth:     sql.NullString{String: util.Value(req.CountryOfBirth), Valid: req.CountryOfBirth != nil},
-		FirstName:          sql.NullString{String: util.Value(req.FirstName), Valid: req.FirstName != nil},
-		LastName:           sql.NullString{String: util.Value(req.LastName), Valid: req.LastName != nil},
-		IsActive:           sql.NullBool{Bool: util.Value(req.IsActive), Valid: req.IsActive != nil},
+	user, err := server.services.Users.AdminUpdateUser(ctx, service.AdminUpdateUserInput{
 		UserID:             uriReq.ID,
-	}
-
-	user, err := server.store.UpdateUser(ctx, arg)
+		Username:           req.Username,
+		Email:              req.Email,
+		Password:           req.Password,
+		UserType:           req.UserType,
+		EmailVerified:      req.EmailVerified,
+		TimeZone:           req.TimeZone,
+		LanguagePreference: req.LanguagePreference,
+		CountryOfResidence: req.CountryOfResidence,
+		CountryOfBirth:     req.CountryOfBirth,
+		FirstName:          req.FirstName,
+		LastName:           req.LastName,
+		IsActive:           req.IsActive,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, newUserResponse(user))
+	ctx.JSON(http.StatusOK, newUserResponseFromServiceUser(user))
 }
 
 // deleteUserRequest represents the URI parameters for deleting a single user.
@@ -389,9 +361,11 @@ func (server *Server) deleteUser(ctx *gin.Context) {
 		return
 	}
 
-	err := server.store.DeleteUserByID(ctx, req.ID)
+	err := server.services.Users.DeleteUser(ctx, service.DeleteUserInput{
+		UserID: req.ID,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
@@ -437,7 +411,7 @@ func (server *Server) loginUser(ctx *gin.Context) {
 		AccessTokenExpiresAt:  args.AccessTokenExpiresAt,
 		RefreshToken:          args.RefreshToken,
 		RefreshTokenExpiresAt: args.RefreshTokenExpiresAt,
-		User:                  newUserResponseFromAuthUser(args.User),
+		User:                  newUserResponseFromServiceUser(args.User),
 	}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/rate-pulse-api/api/user_test.go
+++ b/rate-pulse-api/api/user_test.go
@@ -6,12 +6,30 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateUser(t *testing.T) {
+func makeJSONRequest(t *testing.T, method, path string, payload map[string]any) *http.Request {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func serveRequest(server *Server, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, req)
+	return w
+}
+
+func TestCreateUserValidation(t *testing.T) {
 	tests := []struct {
 		name         string
 		payload      map[string]any
@@ -20,26 +38,42 @@ func TestCreateUser(t *testing.T) {
 		{
 			name: "missing username",
 			payload: map[string]any{
-				"email":    "test@example.com",
-				"password": "StrongPass123!xyz",
+				"email":      "test@example.com",
+				"password":   "StrongPass123!xyz",
+				"first_name": "Test",
+				"last_name":  "User",
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "missing first name",
+			payload: map[string]any{
+				"username":  "testuser",
+				"email":     "test@example.com",
+				"password":  "StrongPass123!xyz",
+				"last_name": "User",
 			},
 			expectedCode: http.StatusBadRequest,
 		},
 		{
 			name: "invalid email",
 			payload: map[string]any{
-				"username": "testuser",
-				"email":    "not-an-email",
-				"password": "StrongPass123!xyz",
+				"username":   "testuser",
+				"email":      "not-an-email",
+				"password":   "StrongPass123!xyz",
+				"first_name": "Test",
+				"last_name":  "User",
 			},
 			expectedCode: http.StatusBadRequest,
 		},
 		{
 			name: "weak password",
 			payload: map[string]any{
-				"username": "testuser",
-				"email":    "test@example.com",
-				"password": "123",
+				"username":   "testuser",
+				"email":      "test@example.com",
+				"password":   "123",
+				"first_name": "Test",
+				"last_name":  "User",
 			},
 			expectedCode: http.StatusBadRequest,
 		},
@@ -48,72 +82,180 @@ func TestCreateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := newTestServer(t, &db.Store{})
+			req := makeJSONRequest(t, http.MethodPost, "/users/signup", tt.payload)
+			w := serveRequest(server, req)
 
-			body, _ := json.Marshal(tt.payload)
-			req := httptest.NewRequest(http.MethodPost, "/users/signup", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-
-			w := httptest.NewRecorder()
-			server.router.ServeHTTP(w, req)
-
-			require.Equal(t, tt.expectedCode, w.Code, "Wrong status code for test: "+tt.name)
+			require.Equal(t, tt.expectedCode, w.Code)
 		})
 	}
 }
 
-func TestLoginUser(t *testing.T) {
+func TestLoginUserValidation(t *testing.T) {
 	tests := []struct {
 		name         string
 		payload      map[string]any
 		expectedCode int
-		description  string
 	}{
 		{
-			name:         "missing_email",
+			name:         "missing email",
 			payload:      map[string]any{"password": "StrongPass123!xyz"},
 			expectedCode: http.StatusBadRequest,
-			description:  "should fail when email is missing",
 		},
 		{
-			name:         "missing_password",
+			name:         "missing password",
 			payload:      map[string]any{"email": "test@example.com"},
 			expectedCode: http.StatusBadRequest,
-			description:  "should fail when password is missing",
 		},
 		{
-			name:         "empty_email",
+			name:         "empty email",
 			payload:      map[string]any{"email": "", "password": "StrongPass123!xyz"},
 			expectedCode: http.StatusBadRequest,
-			description:  "should fail when email is empty",
 		},
 		{
-			name:         "empty_password",
+			name:         "empty password",
 			payload:      map[string]any{"email": "test@example.com", "password": ""},
 			expectedCode: http.StatusBadRequest,
-			description:  "should fail when password is empty",
 		},
 		{
-			name:         "invalid_email_format",
+			name:         "invalid email format",
 			payload:      map[string]any{"email": "not-an-email", "password": "StrongPass123!xyz"},
 			expectedCode: http.StatusBadRequest,
-			description:  "should fail on invalid email format",
-		},
-		{
-			name:         "email_with_whitespace",
-			payload:      map[string]any{"email": "  test@example.com  ", "password": "StrongPass123!xyz"},
-			expectedCode: http.StatusBadRequest,
-			description:  "whitespace should be trimmed by normalizeEmail",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := newTestServer(t, &db.Store{})
-			body, _ := json.Marshal(tt.payload)
-			req := httptest.NewRequest(http.MethodPost, "/users/signin", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-			server.router.ServeHTTP(w, req)
-			require.Equal(t, tt.expectedCode, w.Code, tt.description)
+			req := makeJSONRequest(t, http.MethodPost, "/users/signin", tt.payload)
+			w := serveRequest(server, req)
+
+			require.Equal(t, tt.expectedCode, w.Code)
 		})
 	}
+}
+
+func TestLogoutUserValidation(t *testing.T) {
+	server := newTestServer(t, &db.Store{})
+
+	req := makeJSONRequest(t, http.MethodPost, "/users/signout", map[string]any{})
+	w := serveRequest(server, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestProtectedUserRoutesRequireAuth(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   map[string]any
+	}{
+		{"get user", http.MethodGet, "/users/1", nil},
+		{"list users", http.MethodGet, "/users?page_id=1&page_size=5", nil},
+		{"update user", http.MethodPut, "/users/1", map[string]any{"first_name": "Test"}},
+		{"admin update user", http.MethodPut, "/admin/users/1", map[string]any{"user_type": "admin"}},
+		{"delete user", http.MethodDelete, "/admin/users/1", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestServer(t, &db.Store{})
+
+			var req *http.Request
+			if tt.body != nil {
+				req = makeJSONRequest(t, tt.method, tt.path, tt.body)
+			} else {
+				req = httptest.NewRequest(tt.method, tt.path, nil)
+			}
+
+			w := serveRequest(server, req)
+
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}
+
+func TestAdminUserRoutesRequireAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   map[string]any
+	}{
+		{"admin update user", http.MethodPut, "/admin/users/1", map[string]any{"user_type": "admin"}},
+		{"delete user", http.MethodDelete, "/admin/users/1", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestServer(t, &db.Store{})
+
+			var req *http.Request
+			if tt.body != nil {
+				req = makeJSONRequest(t, tt.method, tt.path, tt.body)
+			} else {
+				req = httptest.NewRequest(tt.method, tt.path, nil)
+			}
+
+			addAuthorization(
+				t,
+				req,
+				server.tokenMaker,
+				authorizationTypeBearer,
+				1,
+				"user@example.com",
+				"testuser",
+				UserTypeFree,
+				time.Minute,
+			)
+
+			w := serveRequest(server, req)
+
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}
+
+func TestListUsersBinding(t *testing.T) {
+	server := newTestServer(t, &db.Store{})
+
+	req := httptest.NewRequest(http.MethodGet, "/users?page_id=0&page_size=5", nil)
+	addAuthorization(
+		t,
+		req,
+		server.tokenMaker,
+		authorizationTypeBearer,
+		1,
+		"user@example.com",
+		"testuser",
+		UserTypeFree,
+		time.Minute,
+	)
+
+	w := serveRequest(server, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateUserBinding(t *testing.T) {
+	server := newTestServer(t, &db.Store{})
+
+	req := makeJSONRequest(t, http.MethodPut, "/users/0", map[string]any{
+		"first_name": "Test",
+	})
+	addAuthorization(
+		t,
+		req,
+		server.tokenMaker,
+		authorizationTypeBearer,
+		1,
+		"user@example.com",
+		"testuser",
+		UserTypeFree,
+		time.Minute,
+	)
+
+	w := serveRequest(server, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/rate-pulse-api/service/auth.go
+++ b/rate-pulse-api/service/auth.go
@@ -1,3 +1,7 @@
+/*
+auth service is responsible for handling all authentication related operations.
+It provides methods for creating users, signing in users, renewing access tokens, and signing out users.
+*/
 package service
 
 import (
@@ -26,19 +30,19 @@ func NewAuthService(config util.Config, store *db.Store, tokenMaker token.Maker)
 	}
 }
 
-func (s *AuthService) CreateUser(ctx context.Context, input CreateUserInput) (AuthUser, error) {
+func (s *AuthService) CreateUser(ctx context.Context, input CreateUserInput) (User, error) {
 	// Normalize the email address
 	email := util.NormalizeEmail(input.Email)
 
 	// Check if the password is weak or not
 	if err := util.ValidatePassword(input.Password); err != nil {
-		return AuthUser{}, Wrap(err, ErrInvalidInput.Code, "weak password")
+		return User{}, Wrap(err, ErrInvalidInput.Code, "weak password")
 	}
 
 	// Hash the password before storing
 	hashedPassword, err := util.HashPassword(input.Password)
 	if err != nil {
-		return AuthUser{}, Wrap(err, ErrInternal.Code, "failed to hash password")
+		return User{}, Wrap(err, ErrInternal.Code, "failed to hash password")
 	}
 
 	user, err := s.store.CreateUser(ctx, db.CreateUserParams{
@@ -58,11 +62,11 @@ func (s *AuthService) CreateUser(ctx context.Context, input CreateUserInput) (Au
 	if err != nil {
 		var pqErr *pq.Error
 		if errors.As(err, &pqErr) && pqErr.Code.Name() == "unique_violation" {
-			return AuthUser{}, Wrap(err, ErrDuplicateEmail.Code, ErrDuplicateEmail.Message)
+			return User{}, Wrap(err, ErrDuplicateEmail.Code, ErrDuplicateEmail.Message)
 		}
-		return AuthUser{}, Wrap(err, ErrInternal.Code, "failed to create user")
+		return User{}, Wrap(err, ErrInternal.Code, "failed to create user")
 	}
-	return newAuthUser(user), nil
+	return NewUser(user), nil
 }
 
 func (s *AuthService) SignIn(ctx context.Context, input SignInInput) (SignInResult, error) {
@@ -143,7 +147,7 @@ func (s *AuthService) SignIn(ctx context.Context, input SignInInput) (SignInResu
 		AccessTokenExpiresAt:  accessPayload.ExpiredAt,
 		RefreshToken:          refreshToken,
 		RefreshTokenExpiresAt: refreshPayload.ExpiredAt,
-		User:                  newAuthUser(user),
+		User:                  NewUser(user),
 	}
 	return res, nil
 }
@@ -205,23 +209,4 @@ func (s *AuthService) SignOut(ctx context.Context, refreshToken string) error {
 		return Wrap(errors.New("refresh token is required"), ErrInvalidInput.Code, "refresh token is required")
 	}
 	return nil
-}
-
-func newAuthUser(user db.User) AuthUser {
-	return AuthUser{
-		UserID:             user.UserID,
-		Username:           user.Username,
-		Email:              user.Email,
-		UserType:           user.UserType.String,
-		EmailVerified:      user.EmailVerified.Bool,
-		TimeZone:           user.TimeZone.String,
-		LanguagePreference: user.LanguagePreference.String,
-		CountryOfResidence: user.CountryOfResidence.String,
-		CountryOfBirth:     user.CountryOfBirth.String,
-		FirstName:          user.FirstName.String,
-		LastName:           user.LastName.String,
-		IsActive:           user.IsActive.Bool,
-		CreatedAt:          user.CreatedAt.Time,
-		UpdatedAt:          user.UpdatedAt.Time,
-	}
 }

--- a/rate-pulse-api/service/auth.go
+++ b/rate-pulse-api/service/auth.go
@@ -1,0 +1,227 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/token"
+	"github.com/ThanhVinhTong/rate-pulse/util"
+	"github.com/lib/pq"
+)
+
+type AuthService struct {
+	config     util.Config
+	store      *db.Store
+	tokenMaker token.Maker
+}
+
+func NewAuthService(config util.Config, store *db.Store, tokenMaker token.Maker) *AuthService {
+	return &AuthService{
+		config:     config,
+		store:      store,
+		tokenMaker: tokenMaker,
+	}
+}
+
+func (s *AuthService) CreateUser(ctx context.Context, input CreateUserInput) (AuthUser, error) {
+	// Normalize the email address
+	email := util.NormalizeEmail(input.Email)
+
+	// Check if the password is weak or not
+	if err := util.ValidatePassword(input.Password); err != nil {
+		return AuthUser{}, Wrap(err, ErrInvalidInput.Code, "weak password")
+	}
+
+	// Hash the password before storing
+	hashedPassword, err := util.HashPassword(input.Password)
+	if err != nil {
+		return AuthUser{}, Wrap(err, ErrInternal.Code, "failed to hash password")
+	}
+
+	user, err := s.store.CreateUser(ctx, db.CreateUserParams{
+		Username:           input.Username,
+		Email:              email,
+		Password:           hashedPassword,
+		UserType:           sql.NullString{String: "free", Valid: true},
+		EmailVerified:      sql.NullBool{Bool: false, Valid: true},
+		TimeZone:           sql.NullString{String: input.TimeZone, Valid: true},
+		LanguagePreference: sql.NullString{String: input.LanguagePreference, Valid: true},
+		CountryOfResidence: sql.NullString{String: input.CountryOfResidence, Valid: true},
+		CountryOfBirth:     sql.NullString{String: input.CountryOfBirth, Valid: true},
+		IsActive:           sql.NullBool{Bool: true, Valid: true},
+		LastName:           sql.NullString{String: input.LastName, Valid: true},
+		FirstName:          sql.NullString{String: input.FirstName, Valid: true},
+	})
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr.Code.Name() == "unique_violation" {
+			return AuthUser{}, Wrap(err, ErrDuplicateEmail.Code, ErrDuplicateEmail.Message)
+		}
+		return AuthUser{}, Wrap(err, ErrInternal.Code, "failed to create user")
+	}
+	return newAuthUser(user), nil
+}
+
+func (s *AuthService) SignIn(ctx context.Context, input SignInInput) (SignInResult, error) {
+	// Early validation to prevent hitting database on bad input
+	if input.Email == "" {
+		return SignInResult{}, Wrap(errors.New("email is required"), ErrInvalidInput.Code, "email is required")
+	}
+	if len(input.Email) > 254 {
+		return SignInResult{}, Wrap(errors.New("email is too long"), ErrInvalidInput.Code, "email is too long")
+	}
+	if input.Password == "" {
+		return SignInResult{}, Wrap(errors.New("password is required"), ErrInvalidInput.Code, "password is required")
+	}
+
+	// Normalize the email address
+	email := util.NormalizeEmail(input.Email)
+
+	// check exists
+	user, err := s.store.GetUserByEmail(ctx, email)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return SignInResult{}, Wrap(err, ErrInvalidCredentials.Code, "invalid email or password")
+		}
+		return SignInResult{}, Wrap(err, ErrInternal.Code, "failed to get user by email")
+	}
+
+	// check password
+	if err := util.CheckPassword(input.Password, user.Password); err != nil {
+		return SignInResult{}, Wrap(err, ErrInvalidCredentials.Code, "invalid email or password")
+	}
+
+	// Check if the user is email verified
+	// TODO: Implement this check after finishing email verification
+
+	// Check if the user is active
+	if user.IsActive.Valid && !user.IsActive.Bool {
+		return SignInResult{}, Wrap(errors.New("user is inactive"), ErrInvalidCredentials.Code, "user is inactive")
+	}
+
+	accessToken, accessPayload, err := s.tokenMaker.CreateToken(
+		user.UserID,
+		user.Username,
+		user.Email,
+		user.UserType.String,
+		s.config.AccessTokenDuration,
+	)
+	if err != nil {
+		return SignInResult{}, Wrap(err, ErrInternal.Code, "failed to create access token")
+	}
+
+	refreshToken, refreshPayload, err := s.tokenMaker.CreateToken(
+		user.UserID,
+		user.Username,
+		user.Email,
+		user.UserType.String,
+		s.config.RefreshTokenDuration,
+	)
+	if err != nil {
+		return SignInResult{}, Wrap(err, ErrInternal.Code, "failed to create refresh token")
+	}
+
+	session, err := s.store.CreateSession(ctx, db.CreateSessionParams{
+		SessionID:    refreshPayload.ID,
+		UserID:       user.UserID,
+		RefreshToken: refreshToken,
+		UserAgent:    input.UserAgent,
+		ClientIp:     input.ClientIP,
+		IsBlocked:    sql.NullBool{Bool: false, Valid: true},
+		ExpiresAt:    refreshPayload.ExpiredAt,
+	})
+	if err != nil {
+		return SignInResult{}, Wrap(err, ErrInternal.Code, "failed to create session")
+	}
+
+	res := SignInResult{
+		SessionID:             session.SessionID,
+		AccessToken:           accessToken,
+		AccessTokenExpiresAt:  accessPayload.ExpiredAt,
+		RefreshToken:          refreshToken,
+		RefreshTokenExpiresAt: refreshPayload.ExpiredAt,
+		User:                  newAuthUser(user),
+	}
+	return res, nil
+}
+
+func (s *AuthService) RenewAccessToken(ctx context.Context, input RenewAccessTokenInput) (RenewAccessTokenResult, error) {
+	if input.RefreshToken == "" {
+		return RenewAccessTokenResult{}, Wrap(errors.New("refresh token is required"), ErrInvalidInput.Code, "refresh token is required")
+	}
+
+	refreshPayload, err := s.tokenMaker.VerifyToken(input.RefreshToken)
+	if err != nil {
+		return RenewAccessTokenResult{}, Wrap(err, ErrUnauthorized.Code, "invalid refresh token")
+	}
+
+	session, err := s.store.GetSessionByID(ctx, refreshPayload.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RenewAccessTokenResult{}, Wrap(err, ErrSessionNotFound.Code, "session not found")
+		}
+		return RenewAccessTokenResult{}, Wrap(err, ErrInternal.Code, "failed to get session")
+	}
+
+	if session.IsBlocked.Valid && session.IsBlocked.Bool {
+		return RenewAccessTokenResult{}, Wrap(errors.New("session is blocked"), ErrSessionBlocked.Code, "session is blocked")
+	}
+
+	if session.UserID != refreshPayload.UserID {
+		return RenewAccessTokenResult{}, Wrap(errors.New("incorrect session user"), ErrUnauthorized.Code, "invalid session")
+	}
+
+	if session.RefreshToken != input.RefreshToken {
+		return RenewAccessTokenResult{}, Wrap(errors.New("mismatched session token"), ErrUnauthorized.Code, "invalid session")
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		return RenewAccessTokenResult{}, Wrap(errors.New("session expired"), ErrSessionExpired.Code, "session expired")
+	}
+
+	accessToken, accessPayload, err := s.tokenMaker.CreateToken(
+		refreshPayload.UserID,
+		refreshPayload.Username,
+		refreshPayload.Email,
+		refreshPayload.UserType,
+		s.config.AccessTokenDuration,
+	)
+	if err != nil {
+		return RenewAccessTokenResult{}, Wrap(err, ErrInternal.Code, "failed to create access token")
+	}
+
+	return RenewAccessTokenResult{
+		AccessToken:          accessToken,
+		AccessTokenExpiresAt: accessPayload.ExpiredAt,
+	}, nil
+}
+
+func (s *AuthService) SignOut(ctx context.Context, refreshToken string) error {
+	// TODO: Implement real signout after adding a query to block or revoke sessions.
+	if refreshToken == "" {
+		return Wrap(errors.New("refresh token is required"), ErrInvalidInput.Code, "refresh token is required")
+	}
+	return nil
+}
+
+func newAuthUser(user db.User) AuthUser {
+	return AuthUser{
+		UserID:             user.UserID,
+		Username:           user.Username,
+		Email:              user.Email,
+		UserType:           user.UserType.String,
+		EmailVerified:      user.EmailVerified.Bool,
+		TimeZone:           user.TimeZone.String,
+		LanguagePreference: user.LanguagePreference.String,
+		CountryOfResidence: user.CountryOfResidence.String,
+		CountryOfBirth:     user.CountryOfBirth.String,
+		FirstName:          user.FirstName.String,
+		LastName:           user.LastName.String,
+		IsActive:           user.IsActive.Bool,
+		CreatedAt:          user.CreatedAt.Time,
+		UpdatedAt:          user.UpdatedAt.Time,
+	}
+}

--- a/rate-pulse-api/service/auth_test.go
+++ b/rate-pulse-api/service/auth_test.go
@@ -1,0 +1,303 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/token"
+	"github.com/ThanhVinhTong/rate-pulse/util"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAuthService(t *testing.T) (*AuthService, sqlmock.Sqlmock, token.Maker) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	config := util.Config{
+		TokenSymmetricKey:    util.RandomString(32),
+		AccessTokenDuration:  time.Minute,
+		RefreshTokenDuration: time.Hour,
+	}
+
+	tokenMaker, err := token.NewPasetoMaker(config.TokenSymmetricKey)
+	require.NoError(t, err)
+
+	store := db.NewStore(sqlDB)
+
+	return NewAuthService(config, store, tokenMaker), mock, tokenMaker
+}
+
+func requireServiceErrorCode(t *testing.T, err error, expectedCode string) {
+	t.Helper()
+
+	require.Error(t, err)
+	require.True(t, IsServiceError(err))
+	require.Equal(t, expectedCode, ServiceErrorCode(err))
+}
+
+func TestAuthServiceCreateUserValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        CreateUserInput
+		expectedCode string
+	}{
+		{
+			name: "weak password",
+			input: CreateUserInput{
+				Username: "testuser",
+				Email:    "test@example.com",
+				Password: "123",
+			},
+			expectedCode: ErrInvalidInput.Code,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authService, mock, _ := newTestAuthService(t)
+
+			user, err := authService.CreateUser(context.Background(), tt.input)
+
+			requireServiceErrorCode(t, err, tt.expectedCode)
+			require.Empty(t, user)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestAuthServiceSignInValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        SignInInput
+		expectedCode string
+	}{
+		{
+			name: "missing email",
+			input: SignInInput{
+				Password: "correct horse battery staple",
+			},
+			expectedCode: ErrInvalidInput.Code,
+		},
+		{
+			name: "missing password",
+			input: SignInInput{
+				Email: "test@example.com",
+			},
+			expectedCode: ErrInvalidInput.Code,
+		},
+		{
+			name: "email too long",
+			input: SignInInput{
+				Email:    util.RandomString(255) + "@example.com",
+				Password: "correct horse battery staple",
+			},
+			expectedCode: ErrInvalidInput.Code,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authService, mock, _ := newTestAuthService(t)
+
+			result, err := authService.SignIn(context.Background(), tt.input)
+
+			requireServiceErrorCode(t, err, tt.expectedCode)
+			require.Empty(t, result)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestAuthServiceSignInUserNotFound(t *testing.T) {
+	authService, mock, _ := newTestAuthService(t)
+
+	mock.ExpectQuery("SELECT user_id, username, email, password").
+		WithArgs("missing@example.com").
+		WillReturnError(sql.ErrNoRows)
+
+	result, err := authService.SignIn(context.Background(), SignInInput{
+		Email:    "missing@example.com",
+		Password: "correct horse battery staple",
+	})
+
+	requireServiceErrorCode(t, err, ErrInvalidCredentials.Code)
+	require.Empty(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAuthServiceRenewAccessTokenSessionNotFound(t *testing.T) {
+	authService, mock, tokenMaker := newTestAuthService(t)
+
+	refreshToken, refreshPayload, err := tokenMaker.CreateToken(
+		42,
+		"testuser",
+		"test@example.com",
+		"free",
+		time.Hour,
+	)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT session_id, user_id, refresh_token").
+		WithArgs(refreshPayload.ID).
+		WillReturnError(sql.ErrNoRows)
+
+	result, err := authService.RenewAccessToken(context.Background(), RenewAccessTokenInput{
+		RefreshToken: refreshToken,
+	})
+
+	requireServiceErrorCode(t, err, ErrSessionNotFound.Code)
+	require.Empty(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAuthServiceRenewAccessTokenSuccess(t *testing.T) {
+	authService, mock, tokenMaker := newTestAuthService(t)
+
+	refreshToken, refreshPayload, err := tokenMaker.CreateToken(
+		42,
+		"testuser",
+		"test@example.com",
+		"free",
+		time.Hour,
+	)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT session_id, user_id, refresh_token").
+		WithArgs(refreshPayload.ID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id",
+			"user_id",
+			"refresh_token",
+			"user_agent",
+			"client_ip",
+			"is_blocked",
+			"expires_at",
+			"created_at",
+			"updated_at",
+		}).AddRow(
+			refreshPayload.ID,
+			refreshPayload.UserID,
+			refreshToken,
+			"test-agent",
+			"127.0.0.1",
+			sql.NullBool{Bool: false, Valid: true},
+			refreshPayload.ExpiredAt,
+			sql.NullTime{Time: time.Now(), Valid: true},
+			sql.NullTime{Time: time.Now(), Valid: true},
+		))
+
+	result, err := authService.RenewAccessToken(context.Background(), RenewAccessTokenInput{
+		RefreshToken: refreshToken,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.AccessToken)
+	require.True(t, result.AccessTokenExpiresAt.After(time.Now()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAuthServiceSignInSuccess(t *testing.T) {
+	authService, mock, _ := newTestAuthService(t)
+
+	const password = "correct horse battery staple"
+
+	hashedPassword, err := util.HashPassword(password)
+	require.NoError(t, err)
+
+	userID := int32(42)
+	sessionID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT user_id, username, email, password").
+		WithArgs("test@example.com").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"user_id",
+			"username",
+			"email",
+			"password",
+			"user_type",
+			"email_verified",
+			"time_zone",
+			"language_preference",
+			"country_of_residence",
+			"country_of_birth",
+			"is_active",
+			"created_at",
+			"updated_at",
+			"first_name",
+			"last_name",
+		}).AddRow(
+			userID,
+			"testuser",
+			"test@example.com",
+			hashedPassword,
+			sql.NullString{String: "free", Valid: true},
+			sql.NullBool{Bool: false, Valid: true},
+			sql.NullString{String: "UTC", Valid: true},
+			sql.NullString{String: "en", Valid: true},
+			sql.NullString{String: "AU", Valid: true},
+			sql.NullString{String: "VN", Valid: true},
+			sql.NullBool{Bool: true, Valid: true},
+			sql.NullTime{Time: now, Valid: true},
+			sql.NullTime{Time: now, Valid: true},
+			sql.NullString{String: "Test", Valid: true},
+			sql.NullString{String: "User", Valid: true},
+		))
+
+	mock.ExpectQuery("INSERT INTO sessions").
+		WithArgs(
+			sqlmock.AnyArg(),
+			userID,
+			sqlmock.AnyArg(),
+			"test-agent",
+			"127.0.0.1",
+			sql.NullBool{Bool: false, Valid: true},
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id",
+			"user_id",
+			"refresh_token",
+			"user_agent",
+			"client_ip",
+			"is_blocked",
+			"expires_at",
+			"created_at",
+			"updated_at",
+		}).AddRow(
+			sessionID,
+			userID,
+			"refresh-token",
+			"test-agent",
+			"127.0.0.1",
+			sql.NullBool{Bool: false, Valid: true},
+			time.Now().Add(time.Hour),
+			sql.NullTime{Time: now, Valid: true},
+			sql.NullTime{Time: now, Valid: true},
+		))
+
+	result, err := authService.SignIn(context.Background(), SignInInput{
+		Email:     "test@example.com",
+		Password:  password,
+		UserAgent: "test-agent",
+		ClientIP:  "127.0.0.1",
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.AccessToken)
+	require.NotEmpty(t, result.RefreshToken)
+	require.Equal(t, userID, result.User.UserID)
+	require.Equal(t, "test@example.com", result.User.Email)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/rate-pulse-api/service/errors.go
+++ b/rate-pulse-api/service/errors.go
@@ -21,6 +21,9 @@ var (
 	ErrSessionBlocked     = NewError("SESSION_BLOCKED", "session is blocked")            // 401
 	ErrSessionExpired     = NewError("SESSION_EXPIRED", "session expired")               // 401
 
+	// Not found errors (4xx)
+	ErrNotFound = NewError("NOT_FOUND", "not found") // 404
+
 	// Conflict errors (4xx)
 	ErrDuplicateEmail = NewError("DUPLICATE_EMAIL", "email already exists") // 409
 

--- a/rate-pulse-api/service/errors.go
+++ b/rate-pulse-api/service/errors.go
@@ -1,0 +1,83 @@
+package service
+
+import "errors"
+
+// Error represents a service layer error with rich context.
+type Error struct {
+	Code    string // Machine-readable error code
+	Message string // Human-readable message
+	Err     error  // Underlying error (for wrapping)
+}
+
+var (
+	// Input / Validation errors (4xx)
+	ErrInvalidInput = NewError("INVALID_INPUT", "invalid input") // 400
+
+	// Authentication / Authorization (4xx)
+	ErrInvalidCredentials = NewError("INVALID_CREDENTIALS", "invalid email or password") // 401
+	ErrUnauthorized       = NewError("UNAUTHORIZED", "unauthorized")                     // 401
+	ErrInactiveUser       = NewError("INACTIVE_USER", "user is inactive")                // 401
+	ErrSessionNotFound    = NewError("SESSION_NOT_FOUND", "session not found")           // 401
+	ErrSessionBlocked     = NewError("SESSION_BLOCKED", "session is blocked")            // 401
+	ErrSessionExpired     = NewError("SESSION_EXPIRED", "session expired")               // 401
+
+	// Conflict errors (4xx)
+	ErrDuplicateEmail = NewError("DUPLICATE_EMAIL", "email already exists") // 409
+
+	// Server errors (5xx)
+	ErrInternal = NewError("INTERNAL_SERVER_ERROR", "internal server error") // 500
+)
+
+// NewError creates a new service error
+func NewError(code, message string) Error {
+	return Error{
+		Code:    code,
+		Message: message,
+	}
+}
+
+// Wrap wraps an underlying error
+func Wrap(err error, code, message string) Error {
+	return Error{
+		Code:    code,
+		Message: message,
+		Err:     err,
+	}
+}
+
+// Error implements the error interface
+func (e Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "internal server error"
+}
+
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// Helper functions
+func IsServiceError(err error) bool {
+	var serviceErr Error
+	return errors.As(err, &serviceErr)
+}
+
+func ServiceErrorCode(err error) string {
+	var serviceErr Error
+	if errors.As(err, &serviceErr) {
+		return serviceErr.Code
+	}
+	return "INTERNAL_SERVER_ERROR"
+}
+
+func ServiceErrorMessage(err error) string {
+	var serviceErr Error
+	if errors.As(err, &serviceErr) {
+		return serviceErr.Message
+	}
+	return "internal server error"
+}

--- a/rate-pulse-api/service/helpers.go
+++ b/rate-pulse-api/service/helpers.go
@@ -1,0 +1,25 @@
+package service
+
+import db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+
+/*
+	Helper function to create a new User from a db.User.
+*/
+func NewUser(user db.User) User {
+	return User{
+		UserID:             user.UserID,
+		Username:           user.Username,
+		Email:              user.Email,
+		UserType:           user.UserType.String,
+		EmailVerified:      user.EmailVerified.Bool,
+		TimeZone:           user.TimeZone.String,
+		LanguagePreference: user.LanguagePreference.String,
+		CountryOfResidence: user.CountryOfResidence.String,
+		CountryOfBirth:     user.CountryOfBirth.String,
+		FirstName:          user.FirstName.String,
+		LastName:           user.LastName.String,
+		IsActive:           user.IsActive.Bool,
+		CreatedAt:          user.CreatedAt.Time,
+		UpdatedAt:          user.UpdatedAt.Time,
+	}
+}

--- a/rate-pulse-api/service/models.go
+++ b/rate-pulse-api/service/models.go
@@ -6,6 +6,26 @@ import (
 	"github.com/google/uuid"
 )
 
+type User struct {
+	UserID             int32
+	Username           string
+	Email              string
+	UserType           string
+	EmailVerified      bool
+	TimeZone           string
+	LanguagePreference string
+	CountryOfResidence string
+	CountryOfBirth     string
+	FirstName          string
+	LastName           string
+	IsActive           bool
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+/*
+auth service models
+*/
 type CreateUserInput struct {
 	Username           string
 	Email              string
@@ -29,33 +49,61 @@ type RenewAccessTokenInput struct {
 	RefreshToken string
 }
 
-type AuthUser struct {
-	UserID             int32
-	Username           string
-	Email              string
-	UserType           string
-	EmailVerified      bool
-	TimeZone           string
-	LanguagePreference string
-	CountryOfResidence string
-	CountryOfBirth     string
-	FirstName          string
-	LastName           string
-	IsActive           bool
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
-}
-
 type SignInResult struct {
 	SessionID             uuid.UUID
 	AccessToken           string
 	AccessTokenExpiresAt  time.Time
 	RefreshToken          string
 	RefreshTokenExpiresAt time.Time
-	User                  AuthUser
+	User                  User
 }
 
 type RenewAccessTokenResult struct {
 	AccessToken          string
 	AccessTokenExpiresAt time.Time
+}
+
+/*
+user service models
+*/
+type GetUserInput struct {
+	UserID int32
+}
+
+type ListUsersInput struct {
+	PageID   int32
+	PageSize int32
+}
+
+type UpdateUserInput struct {
+	UserID             int32
+	Username           *string
+	Email              *string
+	Password           *string
+	TimeZone           *string
+	LanguagePreference *string
+	CountryOfResidence *string
+	CountryOfBirth     *string
+	FirstName          *string
+	LastName           *string
+}
+
+type AdminUpdateUserInput struct {
+	UserID             int32
+	Username           *string
+	Email              *string
+	Password           *string
+	UserType           *string
+	EmailVerified      *bool
+	TimeZone           *string
+	LanguagePreference *string
+	CountryOfResidence *string
+	CountryOfBirth     *string
+	FirstName          *string
+	LastName           *string
+	IsActive           *bool
+}
+
+type DeleteUserInput struct {
+	UserID int32
 }

--- a/rate-pulse-api/service/models.go
+++ b/rate-pulse-api/service/models.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateUserInput struct {
+	Username           string
+	Email              string
+	Password           string
+	TimeZone           string
+	LanguagePreference string
+	CountryOfResidence string
+	CountryOfBirth     string
+	FirstName          string
+	LastName           string
+}
+
+type SignInInput struct {
+	Email     string
+	Password  string
+	UserAgent string
+	ClientIP  string
+}
+
+type RenewAccessTokenInput struct {
+	RefreshToken string
+}
+
+type AuthUser struct {
+	UserID             int32
+	Username           string
+	Email              string
+	UserType           string
+	EmailVerified      bool
+	TimeZone           string
+	LanguagePreference string
+	CountryOfResidence string
+	CountryOfBirth     string
+	FirstName          string
+	LastName           string
+	IsActive           bool
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+type SignInResult struct {
+	SessionID             uuid.UUID
+	AccessToken           string
+	AccessTokenExpiresAt  time.Time
+	RefreshToken          string
+	RefreshTokenExpiresAt time.Time
+	User                  AuthUser
+}
+
+type RenewAccessTokenResult struct {
+	AccessToken          string
+	AccessTokenExpiresAt time.Time
+}

--- a/rate-pulse-api/service/service.go
+++ b/rate-pulse-api/service/service.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/token"
+	"github.com/ThanhVinhTong/rate-pulse/util"
+)
+
+// Services groups application use cases behind transport layers such as REST and gRPC.
+type Services struct {
+	Auth *AuthService
+}
+
+func NewServices(config util.Config, store *db.Store, tokenMaker token.Maker) *Services {
+	return &Services{
+		Auth: NewAuthService(config, store, tokenMaker),
+	}
+}

--- a/rate-pulse-api/service/service.go
+++ b/rate-pulse-api/service/service.go
@@ -8,11 +8,13 @@ import (
 
 // Services groups application use cases behind transport layers such as REST and gRPC.
 type Services struct {
-	Auth *AuthService
+	Auth  *AuthService
+	Users *UserService
 }
 
 func NewServices(config util.Config, store *db.Store, tokenMaker token.Maker) *Services {
 	return &Services{
-		Auth: NewAuthService(config, store, tokenMaker),
+		Auth:  NewAuthService(config, store, tokenMaker),
+		Users: NewUserService(store),
 	}
 }

--- a/rate-pulse-api/service/user.go
+++ b/rate-pulse-api/service/user.go
@@ -1,0 +1,209 @@
+/*
+user service is responsible for handling all user related operations.
+It provides methods for getting users, listing users, and updating users.
+*/
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/util"
+)
+
+type UserService struct {
+	store *db.Store
+}
+
+func NewUserService(store *db.Store) *UserService {
+	return &UserService{store: store}
+}
+
+/*
+GetUser Service is responsible for getting a user by their ID.
+- Validate user_id > 0
+- Call store.GetUserByID
+- Convert db.User to safe service user model
+- Return ErrNotFound or ErrInternal
+*/
+func (s *UserService) GetUser(ctx context.Context, input GetUserInput) (User, error) {
+	if input.UserID <= 0 {
+		return User{}, Wrap(nil, ErrInvalidInput.Code, "user_id must be greater than 0")
+	}
+
+	user, err := s.store.GetUserByID(ctx, input.UserID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, Wrap(err, ErrNotFound.Code, "user not found")
+		}
+		return User{}, Wrap(err, ErrInternal.Code, "failed to get user by id")
+	}
+
+	return NewUser(user), nil
+}
+
+/*
+ListUsers Service is responsible for listing users with pagination.
+- Validate page_id >= 1
+- Validate page_size range between 5 and 10
+- Calculate offset = (page_id - 1) * page_size
+- Call store.ListUsers
+- Convert []db.User to []User
+- Return ErrInvalidInput, ErrInternal, or ErrNotFound
+*/
+func (s *UserService) ListUsers(ctx context.Context, input ListUsersInput) ([]User, error) {
+	if input.PageID <= 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "page_id must be greater than 0")
+	}
+	if input.PageSize < 5 || input.PageSize > 10 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "page_size must be between 5 and 10")
+	}
+	arg := db.ListUsersParams{
+		Limit:  input.PageSize,
+		Offset: (input.PageID - 1) * input.PageSize,
+	}
+
+	users, err := s.store.ListUsers(ctx, arg)
+	if err != nil {
+		return nil, Wrap(err, ErrInternal.Code, "failed to list users")
+	}
+
+	res := make([]User, len(users))
+	for i, user := range users {
+		res[i] = NewUser(user)
+	}
+	return res, nil
+}
+
+/*
+UpdateUser Service is responsible for updating a user by their ID.
+- Validate user_id > 0
+- Hash password if provided
+- Normalize email if provided
+- Build db.UpdateUserParams
+- Call store.UpdateUser
+- Return safe user model
+*/
+func (s *UserService) UpdateUser(ctx context.Context, input UpdateUserInput) (User, error) {
+	if input.UserID <= 0 {
+		return User{}, Wrap(nil, ErrInvalidInput.Code, "user_id must be greater than 0")
+	}
+
+	var email *string
+	if input.Email != nil {
+		normalized := util.NormalizeEmail(*input.Email)
+		email = &normalized
+	}
+
+	// Hash password if provided
+	var hashedPassword *string
+	if input.Password != nil {
+		hashed, err := util.HashPassword(*input.Password)
+		if err != nil {
+			return User{}, Wrap(err, ErrInternal.Code, "failed to hash password")
+		}
+		hashedPassword = &hashed
+	}
+
+	user, err := s.store.UpdateUser(ctx, db.UpdateUserParams{
+		Username:           sql.NullString{String: util.Value(input.Username), Valid: input.Username != nil},
+		Email:              sql.NullString{String: util.Value(email), Valid: email != nil},
+		Password:           sql.NullString{String: util.Value(hashedPassword), Valid: hashedPassword != nil},
+		TimeZone:           sql.NullString{String: util.Value(input.TimeZone), Valid: input.TimeZone != nil},
+		LanguagePreference: sql.NullString{String: util.Value(input.LanguagePreference), Valid: input.LanguagePreference != nil},
+		CountryOfResidence: sql.NullString{String: util.Value(input.CountryOfResidence), Valid: input.CountryOfResidence != nil},
+		CountryOfBirth:     sql.NullString{String: util.Value(input.CountryOfBirth), Valid: input.CountryOfBirth != nil},
+		FirstName:          sql.NullString{String: util.Value(input.FirstName), Valid: input.FirstName != nil},
+		LastName:           sql.NullString{String: util.Value(input.LastName), Valid: input.LastName != nil},
+		UserID:             input.UserID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, Wrap(err, ErrNotFound.Code, "user not found")
+		}
+		return User{}, Wrap(err, ErrInternal.Code, "failed to update user")
+	}
+	return NewUser(user), nil
+}
+
+/*
+AdminUpdateUser Service is responsible for updating a user by their ID.
+- Validate UserID > 0
+- Hash password if provided
+- Normalize email if provided
+- Validate admin-only UserType if provided
+- Build db.UpdateUserParams
+- Allow UserType, EmailVerified, IsActive
+*/
+func (s *UserService) AdminUpdateUser(ctx context.Context, input AdminUpdateUserInput) (User, error) {
+	if input.UserID <= 0 {
+		return User{}, Wrap(nil, ErrInvalidInput.Code, "user_id must be greater than 0")
+	}
+
+	if input.UserType != nil {
+		switch *input.UserType {
+		case "free", "premium", "enterprise", "admin":
+		default:
+			return User{}, Wrap(nil, ErrInvalidInput.Code, "invalid user_type")
+		}
+	}
+
+	var email *string
+	if input.Email != nil {
+		normalized := util.NormalizeEmail(*input.Email)
+		email = &normalized
+	}
+
+	var hashedPassword *string
+	if input.Password != nil {
+		hashed, err := util.HashPassword(*input.Password)
+		if err != nil {
+			return User{}, Wrap(err, ErrInternal.Code, "failed to hash password")
+		}
+		hashedPassword = &hashed
+	}
+
+	user, err := s.store.UpdateUser(ctx, db.UpdateUserParams{
+		Username:           sql.NullString{String: util.Value(input.Username), Valid: input.Username != nil},
+		Email:              sql.NullString{String: util.Value(email), Valid: email != nil},
+		Password:           sql.NullString{String: util.Value(hashedPassword), Valid: hashedPassword != nil},
+		UserType:           sql.NullString{String: util.Value(input.UserType), Valid: input.UserType != nil},
+		EmailVerified:      sql.NullBool{Bool: util.Value(input.EmailVerified), Valid: input.EmailVerified != nil},
+		TimeZone:           sql.NullString{String: util.Value(input.TimeZone), Valid: input.TimeZone != nil},
+		LanguagePreference: sql.NullString{String: util.Value(input.LanguagePreference), Valid: input.LanguagePreference != nil},
+		CountryOfResidence: sql.NullString{String: util.Value(input.CountryOfResidence), Valid: input.CountryOfResidence != nil},
+		CountryOfBirth:     sql.NullString{String: util.Value(input.CountryOfBirth), Valid: input.CountryOfBirth != nil},
+		FirstName:          sql.NullString{String: util.Value(input.FirstName), Valid: input.FirstName != nil},
+		LastName:           sql.NullString{String: util.Value(input.LastName), Valid: input.LastName != nil},
+		IsActive:           sql.NullBool{Bool: util.Value(input.IsActive), Valid: input.IsActive != nil},
+		UserID:             input.UserID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, Wrap(err, ErrNotFound.Code, "user not found")
+		}
+		return User{}, Wrap(err, ErrInternal.Code, "failed to update user")
+	}
+
+	return NewUser(user), nil
+}
+
+/*
+DeleteUser Service is responsible for deleting a user by their ID.
+- Validate user_id > 0
+- Call store.DeleteUserByID
+- Convert DB errors to service errors
+*/
+func (s *UserService) DeleteUser(ctx context.Context, input DeleteUserInput) error {
+	if input.UserID <= 0 {
+		return Wrap(nil, ErrInvalidInput.Code, "user_id must be greater than 0")
+	}
+
+	if err := s.store.DeleteUserByID(ctx, input.UserID); err != nil {
+		return Wrap(err, ErrInternal.Code, "failed to delete user")
+	}
+
+	return nil
+}

--- a/rate-pulse-api/service/user_test.go
+++ b/rate-pulse-api/service/user_test.go
@@ -1,0 +1,358 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestUserService(t *testing.T) (*UserService, sqlmock.Sqlmock) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	return NewUserService(db.NewStore(sqlDB)), mock
+}
+
+func requireUserServiceErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	require.Error(t, err)
+	require.True(t, IsServiceError(err), "expected service error, got %T: %v", err, err)
+	require.Equal(t, code, ServiceErrorCode(err))
+}
+
+func testDBUserForUserService() db.User {
+	now := time.Now()
+
+	return db.User{
+		UserID:             42,
+		Username:           "testuser",
+		Email:              "test@example.com",
+		Password:           "hashed-password",
+		UserType:           sql.NullString{String: "free", Valid: true},
+		EmailVerified:      sql.NullBool{Bool: false, Valid: true},
+		TimeZone:           sql.NullString{String: "UTC", Valid: true},
+		LanguagePreference: sql.NullString{String: "en", Valid: true},
+		CountryOfResidence: sql.NullString{String: "AU", Valid: true},
+		CountryOfBirth:     sql.NullString{String: "VN", Valid: true},
+		IsActive:           sql.NullBool{Bool: true, Valid: true},
+		CreatedAt:          sql.NullTime{Time: now, Valid: true},
+		UpdatedAt:          sql.NullTime{Time: now, Valid: true},
+		FirstName:          sql.NullString{String: "Test", Valid: true},
+		LastName:           sql.NullString{String: "User", Valid: true},
+	}
+}
+
+func userRows(users ...db.User) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{
+		"user_id",
+		"username",
+		"email",
+		"password",
+		"user_type",
+		"email_verified",
+		"time_zone",
+		"language_preference",
+		"country_of_residence",
+		"country_of_birth",
+		"is_active",
+		"created_at",
+		"updated_at",
+		"first_name",
+		"last_name",
+	})
+
+	for _, user := range users {
+		rows.AddRow(
+			user.UserID,
+			user.Username,
+			user.Email,
+			user.Password,
+			user.UserType,
+			user.EmailVerified,
+			user.TimeZone,
+			user.LanguagePreference,
+			user.CountryOfResidence,
+			user.CountryOfBirth,
+			user.IsActive,
+			user.CreatedAt,
+			user.UpdatedAt,
+			user.FirstName,
+			user.LastName,
+		)
+	}
+
+	return rows
+}
+
+func TestUserServiceGetUserInvalidID(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	user, err := userService.GetUser(context.Background(), GetUserInput{UserID: 0})
+
+	requireUserServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Empty(t, user)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceGetUserNotFound(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	mock.ExpectQuery("SELECT user_id, username, email, password").
+		WithArgs(int32(404)).
+		WillReturnError(sql.ErrNoRows)
+
+	user, err := userService.GetUser(context.Background(), GetUserInput{UserID: 404})
+
+	requireUserServiceErrorCode(t, err, ErrNotFound.Code)
+	require.Empty(t, user)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceGetUserSuccess(t *testing.T) {
+	userService, mock := newTestUserService(t)
+	dbUser := testDBUserForUserService()
+
+	mock.ExpectQuery("SELECT user_id, username, email, password").
+		WithArgs(dbUser.UserID).
+		WillReturnRows(userRows(dbUser))
+
+	user, err := userService.GetUser(context.Background(), GetUserInput{UserID: dbUser.UserID})
+
+	require.NoError(t, err)
+	require.Equal(t, dbUser.UserID, user.UserID)
+	require.Equal(t, dbUser.Email, user.Email)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceListUsersInvalidPageID(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	users, err := userService.ListUsers(context.Background(), ListUsersInput{
+		PageID:   0,
+		PageSize: 5,
+	})
+
+	requireUserServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Nil(t, users)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceListUsersInvalidPageSize(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	users, err := userService.ListUsers(context.Background(), ListUsersInput{
+		PageID:   1,
+		PageSize: 11,
+	})
+
+	requireUserServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Nil(t, users)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceListUsersSuccess(t *testing.T) {
+	userService, mock := newTestUserService(t)
+	user1 := testDBUserForUserService()
+	user2 := testDBUserForUserService()
+	user2.UserID = 43
+	user2.Email = "second@example.com"
+
+	mock.ExpectQuery("SELECT user_id, username, email, password").
+		WithArgs(int32(5), int32(0)).
+		WillReturnRows(userRows(user1, user2))
+
+	users, err := userService.ListUsers(context.Background(), ListUsersInput{
+		PageID:   1,
+		PageSize: 5,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	require.Equal(t, user1.UserID, users[0].UserID)
+	require.Equal(t, user2.UserID, users[1].UserID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceUpdateUserInvalidID(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	user, err := userService.UpdateUser(context.Background(), UpdateUserInput{UserID: 0})
+
+	requireUserServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Empty(t, user)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceUpdateUserNotFound(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	firstName := "Updated"
+
+	mock.ExpectQuery("UPDATE users").
+		WithArgs(
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullBool{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullBool{},
+			sql.NullString{String: firstName, Valid: true},
+			sql.NullString{},
+			int32(42),
+		).
+		WillReturnError(sql.ErrNoRows)
+
+	user, err := userService.UpdateUser(context.Background(), UpdateUserInput{
+		UserID:    42,
+		FirstName: &firstName,
+	})
+
+	requireUserServiceErrorCode(t, err, ErrNotFound.Code)
+	require.Empty(t, user)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceUpdateUserSuccess(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	email := "  TEST@EXAMPLE.COM "
+	firstName := "Updated"
+	updatedUser := testDBUserForUserService()
+	updatedUser.Email = "test@example.com"
+	updatedUser.FirstName = sql.NullString{String: firstName, Valid: true}
+
+	mock.ExpectQuery("UPDATE users").
+		WithArgs(
+			sql.NullString{},
+			sql.NullString{String: "test@example.com", Valid: true},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullBool{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullBool{},
+			sql.NullString{String: firstName, Valid: true},
+			sql.NullString{},
+			int32(42),
+		).
+		WillReturnRows(userRows(updatedUser))
+
+	user, err := userService.UpdateUser(context.Background(), UpdateUserInput{
+		UserID:    42,
+		Email:     &email,
+		FirstName: &firstName,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, updatedUser.Email, user.Email)
+	require.Equal(t, firstName, user.FirstName)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceAdminUpdateUserInvalidUserType(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	userType := "owner"
+
+	user, err := userService.AdminUpdateUser(context.Background(), AdminUpdateUserInput{
+		UserID:   42,
+		UserType: &userType,
+	})
+
+	requireUserServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Empty(t, user)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceAdminUpdateUserSuccess(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	userType := "admin"
+	isActive := true
+	updatedUser := testDBUserForUserService()
+	updatedUser.UserType = sql.NullString{String: userType, Valid: true}
+	updatedUser.IsActive = sql.NullBool{Bool: isActive, Valid: true}
+
+	mock.ExpectQuery("UPDATE users").
+		WithArgs(
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{String: userType, Valid: true},
+			sql.NullBool{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullBool{Bool: isActive, Valid: true},
+			sql.NullString{},
+			sql.NullString{},
+			int32(42),
+		).
+		WillReturnRows(userRows(updatedUser))
+
+	user, err := userService.AdminUpdateUser(context.Background(), AdminUpdateUserInput{
+		UserID:   42,
+		UserType: &userType,
+		IsActive: &isActive,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, userType, user.UserType)
+	require.True(t, user.IsActive)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceDeleteUserInvalidID(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	err := userService.DeleteUser(context.Background(), DeleteUserInput{UserID: 0})
+
+	requireUserServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceDeleteUserDBError(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	mock.ExpectExec("DELETE FROM users").
+		WithArgs(int32(42)).
+		WillReturnError(errors.New("database unavailable"))
+
+	err := userService.DeleteUser(context.Background(), DeleteUserInput{UserID: 42})
+
+	requireUserServiceErrorCode(t, err, ErrInternal.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserServiceDeleteUserSuccess(t *testing.T) {
+	userService, mock := newTestUserService(t)
+
+	mock.ExpectExec("DELETE FROM users").
+		WithArgs(int32(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := userService.DeleteUser(context.Background(), DeleteUserInput{UserID: 42})
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Summary

- Refactored auth and user logic into a new service layer so REST handlers stay focused on HTTP request/response handling.
- Added AuthService and UserService for signup, signin, token renewal, signout, user lookup, listing, updates, admin updates, and deletion.
- Updated REST user/auth handlers to call service methods and map service errors consistently.
- Added unit tests for service-layer auth/user behavior and REST validation/auth middleware coverage.

Why

- This separates business logic from transport logic and prepares the backend for future gRPC support without duplicating auth or user-management behavior across REST and gRPC handlers.