### PR TITLE
feat: added business layer for fx

### DIFF
--- a/rate-pulse-api/api/errors.go
+++ b/rate-pulse-api/api/errors.go
@@ -17,7 +17,10 @@ func RespondServiceError(ctx *gin.Context, err error) {
 		service.ErrSessionBlocked.Code,
 		service.ErrSessionExpired.Code:
 		ctx.JSON(http.StatusUnauthorized, errorResponse(err))
-	case service.ErrDuplicateEmail.Code:
+	case service.ErrNotFound.Code:
+		ctx.JSON(http.StatusNotFound, errorResponse(err))
+	case service.ErrDuplicateEmail.Code,
+		service.ErrDuplicateExchangeRate.Code:
 		ctx.JSON(http.StatusConflict, errorResponse(err))
 	default:
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))

--- a/rate-pulse-api/api/exchange_rate.go
+++ b/rate-pulse-api/api/exchange_rate.go
@@ -1,15 +1,11 @@
 package api
 
 import (
-	"database/sql"
-	"errors"
 	"net/http"
 	"time"
 
-	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
-	"github.com/ThanhVinhTong/rate-pulse/util"
+	"github.com/ThanhVinhTong/rate-pulse/service"
 	"github.com/gin-gonic/gin"
-	"github.com/lib/pq"
 )
 
 // createExchangeRateRequest represents the request body for creating a new exchange rate.
@@ -43,30 +39,17 @@ func (server *Server) createExchangeRate(ctx *gin.Context) {
 		return
 	}
 
-	arg := db.CreateExchangeRateParams{
+	exchangeRate, err := server.services.FX.CreateExchangeRate(ctx, service.CreateExchangeRateInput{
 		RateValue:             req.RateValue,
 		SourceCurrencyID:      req.SourceCurrencyID,
 		DestinationCurrencyID: req.DestinationCurrencyID,
 		ValidFromDate:         req.ValidFromDate,
-		ValidToDate:           sql.NullTime{Time: req.ValidToDate, Valid: !req.ValidToDate.IsZero()},
-		SourceID:              sql.NullInt32{Int32: req.SourceID, Valid: req.SourceID > 0},
-		TypeID:                sql.NullInt32{Int32: req.Type, Valid: req.Type > 0},
-	}
-
-	exchangeRate, err := server.store.CreateExchangeRate(ctx, arg)
+		ValidToDate:           req.ValidToDate,
+		SourceID:              req.SourceID,
+		TypeID:                req.Type,
+	})
 	if err != nil {
-		var pqErr *pq.Error
-		if errors.As(err, &pqErr) {
-			switch pqErr.Code {
-			case "23505":
-				ctx.JSON(http.StatusConflict, gin.H{"error": "duplicate exchange rate"})
-				return
-			case "23503":
-				ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid reference id"})
-				return
-			}
-		}
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
@@ -99,13 +82,11 @@ func (server *Server) getExchangeRate(ctx *gin.Context) {
 		return
 	}
 
-	exchangeRate, err := server.store.GetExchangeRateByID(ctx, req.ID)
+	exchangeRate, err := server.services.FX.GetExchangeRate(ctx, service.GetExchangeRateInput{
+		RateID: req.ID,
+	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			ctx.JSON(http.StatusNotFound, gin.H{"error": "exchange rate not found"})
-			return
-		}
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
@@ -116,7 +97,7 @@ func (server *Server) getExchangeRate(ctx *gin.Context) {
 // PageID starts from 1 and PageSize must be between 5 and 10.
 type listExchangeRateRequest struct {
 	SourceCurrencyID int32 `form:"source_currency_id" binding:"required,min=1"`
-	Limit            int32 `form:"limit,default=20" binding:"min=1,max=1000"`
+	Limit            int32 `form:"limit,default=20" binding:"min=1,max=2000"`
 }
 
 // Response: Array of ExchangeRate objects on success, error message on failure
@@ -131,14 +112,12 @@ func (server *Server) listExchangeRateToday(ctx *gin.Context) {
 		return
 	}
 
-	arg := db.GetAllExchangeRatesTodayNormalisedParams{
+	exchangeRates, err := server.services.FX.ListLatestExchangeRates(ctx, service.ListLatestExchangeRatesInput{
 		SourceCurrencyID: req.SourceCurrencyID,
 		Limit:            req.Limit,
-	}
-
-	exchangeRates, err := server.store.GetAllExchangeRatesTodayNormalised(ctx, arg)
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
@@ -185,20 +164,18 @@ func (server *Server) updateExchangeRate(ctx *gin.Context) {
 		return
 	}
 
-	arg := db.UpdateExchangeRateParams{
+	exchangeRate, err := server.services.FX.UpdateExchangeRate(ctx, service.UpdateExchangeRateInput{
 		RateID:                uriReq.ID,
-		RateValue:             util.Value(req.RateValue),
-		SourceCurrencyID:      util.Value(req.SourceCurrencyID),
-		DestinationCurrencyID: util.Value(req.DestinationCurrencyID),
-		ValidFromDate:         util.Value(req.ValidFromDate),
-		ValidToDate:           sql.NullTime{Time: util.Value(req.ValidToDate), Valid: req.ValidToDate != nil},
-		SourceID:              sql.NullInt32{Int32: util.Value(req.SourceID), Valid: req.SourceID != nil},
-		TypeID:                sql.NullInt32{Int32: util.Value(req.TypeID), Valid: req.TypeID != nil},
-	}
-
-	exchangeRate, err := server.store.UpdateExchangeRate(ctx, arg)
+		RateValue:             req.RateValue,
+		SourceCurrencyID:      req.SourceCurrencyID,
+		DestinationCurrencyID: req.DestinationCurrencyID,
+		ValidFromDate:         req.ValidFromDate,
+		ValidToDate:           req.ValidToDate,
+		SourceID:              req.SourceID,
+		TypeID:                req.TypeID,
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 
@@ -231,9 +208,8 @@ func (server *Server) deleteExchangeRate(ctx *gin.Context) {
 		return
 	}
 
-	err := server.store.DeleteExchangeRate(ctx, req.ID)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+	if err := server.services.FX.DeleteExchangeRate(ctx, service.DeleteExchangeRateInput{RateID: req.ID}); err != nil {
+		RespondServiceError(ctx, err)
 		return
 	}
 
@@ -277,35 +253,16 @@ func (server *Server) getHistoricalData(ctx *gin.Context) {
 		return
 	}
 
-	// Set default and validate data_points
-	if req.DataPoints == 0 {
-		req.DataPoints = 50
-	}
-	if req.DataPoints > 500 {
-		req.DataPoints = 500
-	}
-
-	// Parse time range to duration
-	duration, err := util.ParseTimeRangeToDuration(req.TimeRange)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Calculate start date by subtracting duration from now
-	startDate := time.Now().Add(-duration)
-
-	rows, err := server.store.GetHistoricalData(ctx, db.GetHistoricalDataParams{
+	rows, err := server.services.FX.GetHistoricalData(ctx, service.GetHistoricalDataInput{
 		SourceCurrencyID:      req.SourceCurrencyID,
 		DestinationCurrencyID: req.DestinationCurrencyID,
-		SourceID:              sql.NullInt32{Int32: req.SourceID, Valid: true},
-		UpdatedAt:             sql.NullTime{Time: startDate, Valid: true},
-		TypeID:                sql.NullInt32{Int32: req.TypeID, Valid: true},
-		Ntile:                 req.DataPoints,
+		SourceID:              req.SourceID,
+		TypeID:                req.TypeID,
+		TimeRange:             req.TimeRange,
+		DataPoints:            req.DataPoints,
 	})
-
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		RespondServiceError(ctx, err)
 		return
 	}
 

--- a/rate-pulse-api/db/query/exchange_rate.sql
+++ b/rate-pulse-api/db/query/exchange_rate.sql
@@ -43,13 +43,13 @@ LIMIT $2;
 -- name: UpdateExchangeRate :one
 UPDATE exchange_rates
 SET 
-    rate_value = COALESCE($2, rate_value),
-    source_currency_id = COALESCE($3, source_currency_id),
-    destination_currency_id = COALESCE($4, destination_currency_id),
-    valid_from_date = COALESCE($5, valid_from_date),
-    valid_to_date = COALESCE($6, valid_to_date),
-    source_id = COALESCE($7, source_id),
-    type_id = COALESCE($8, type_id),
+    rate_value = COALESCE(sqlc.narg(rate_value), rate_value),
+    source_currency_id = COALESCE(sqlc.narg(source_currency_id), source_currency_id),
+    destination_currency_id = COALESCE(sqlc.narg(destination_currency_id), destination_currency_id),
+    valid_from_date = COALESCE(sqlc.narg(valid_from_date), valid_from_date),
+    valid_to_date = COALESCE(sqlc.narg(valid_to_date), valid_to_date),
+    source_id = COALESCE(sqlc.narg(source_id), source_id),
+    type_id = COALESCE(sqlc.narg(type_id), type_id),
     updated_at = CURRENT_TIMESTAMP
 WHERE rate_id = $1
 RETURNING *;

--- a/rate-pulse-api/db/sqlc/exchange_rate.sql.go
+++ b/rate-pulse-api/db/sqlc/exchange_rate.sql.go
@@ -336,10 +336,10 @@ RETURNING rate_id, rate_value, source_currency_id, destination_currency_id, vali
 
 type UpdateExchangeRateParams struct {
 	RateID                int32
-	RateValue             string
-	SourceCurrencyID      int32
-	DestinationCurrencyID int32
-	ValidFromDate         time.Time
+	RateValue             sql.NullString
+	SourceCurrencyID      sql.NullInt32
+	DestinationCurrencyID sql.NullInt32
+	ValidFromDate         sql.NullTime
 	ValidToDate           sql.NullTime
 	SourceID              sql.NullInt32
 	TypeID                sql.NullInt32

--- a/rate-pulse-api/service/errors.go
+++ b/rate-pulse-api/service/errors.go
@@ -25,7 +25,8 @@ var (
 	ErrNotFound = NewError("NOT_FOUND", "not found") // 404
 
 	// Conflict errors (4xx)
-	ErrDuplicateEmail = NewError("DUPLICATE_EMAIL", "email already exists") // 409
+	ErrDuplicateEmail        = NewError("DUPLICATE_EMAIL", "email already exists")            // 409
+	ErrDuplicateExchangeRate = NewError("DUPLICATE_EXCHANGE_RATE", "duplicate exchange rate") // 409
 
 	// Server errors (5xx)
 	ErrInternal = NewError("INTERNAL_SERVER_ERROR", "internal server error") // 500

--- a/rate-pulse-api/service/fx.go
+++ b/rate-pulse-api/service/fx.go
@@ -1,0 +1,265 @@
+/*
+fx service is responsible for handling foreign exchange rate use cases.
+It provides methods for creating, reading, listing, updating, deleting, and retrieving historical FX rates.
+*/
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/util"
+	"github.com/lib/pq"
+)
+
+type FXService struct {
+	store *db.Store
+}
+
+func NewFXService(store *db.Store) *FXService {
+	return &FXService{store: store}
+}
+
+/*
+CreateExchangeRate Service is responsible for creating a new exchange rate.
+- Validate required rate fields and positive reference IDs
+- Build db.CreateExchangeRateParams
+- Convert database constraint failures into service errors
+*/
+func (s *FXService) CreateExchangeRate(ctx context.Context, input CreateExchangeRateInput) (ExchangeRate, error) {
+	if err := validateExchangeRateValues(
+		input.RateValue,
+		input.SourceCurrencyID,
+		input.DestinationCurrencyID,
+		input.ValidFromDate,
+		input.ValidToDate,
+	); err != nil {
+		return ExchangeRate{}, err
+	}
+
+	rate, err := s.store.CreateExchangeRate(ctx, db.CreateExchangeRateParams{
+		RateValue:             input.RateValue,
+		SourceCurrencyID:      input.SourceCurrencyID,
+		DestinationCurrencyID: input.DestinationCurrencyID,
+		ValidFromDate:         input.ValidFromDate,
+		ValidToDate:           sql.NullTime{Time: input.ValidToDate, Valid: !input.ValidToDate.IsZero()},
+		SourceID:              sql.NullInt32{Int32: input.SourceID, Valid: input.SourceID > 0},
+		TypeID:                sql.NullInt32{Int32: input.TypeID, Valid: input.TypeID > 0},
+	})
+	if err != nil {
+		return ExchangeRate{}, wrapExchangeRateDBError(err, "failed to create exchange rate")
+	}
+
+	return NewExchangeRate(rate), nil
+}
+
+/*
+GetExchangeRate Service is responsible for getting an exchange rate by ID.
+- Validate rate_id > 0
+- Call store.GetExchangeRateByID
+- Convert database row into service model
+*/
+func (s *FXService) GetExchangeRate(ctx context.Context, input GetExchangeRateInput) (ExchangeRate, error) {
+	if input.RateID <= 0 {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "rate_id must be greater than 0")
+	}
+
+	rate, err := s.store.GetExchangeRateByID(ctx, input.RateID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ExchangeRate{}, Wrap(err, ErrNotFound.Code, "exchange rate not found")
+		}
+		return ExchangeRate{}, Wrap(err, ErrInternal.Code, "failed to get exchange rate by id")
+	}
+
+	return NewExchangeRateFromGetRow(rate), nil
+}
+
+/*
+ListLatestExchangeRates Service is responsible for listing current normalized exchange rates.
+- Validate source currency and limit
+- Delegate latest-rate selection to the repository query
+- Convert database rows into service models
+*/
+func (s *FXService) ListLatestExchangeRates(ctx context.Context, input ListLatestExchangeRatesInput) ([]LatestExchangeRate, error) {
+	if input.SourceCurrencyID <= 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "source_currency_id must be greater than 0")
+	}
+	if input.Limit <= 0 || input.Limit > 10000 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "limit must be between 1 and 10000")
+	}
+
+	rates, err := s.store.GetAllExchangeRatesTodayNormalised(ctx, db.GetAllExchangeRatesTodayNormalisedParams{
+		SourceCurrencyID: input.SourceCurrencyID,
+		Limit:            input.Limit,
+	})
+	if err != nil {
+		return nil, Wrap(err, ErrInternal.Code, "failed to list latest exchange rates")
+	}
+
+	res := make([]LatestExchangeRate, len(rates))
+	for i, rate := range rates {
+		res[i] = NewLatestExchangeRate(rate)
+	}
+	return res, nil
+}
+
+/*
+UpdateExchangeRate Service is responsible for updating an exchange rate by ID.
+- Validate rate_id and any provided IDs/dates
+- Build db.UpdateExchangeRateParams from optional fields
+- Return ErrNotFound when no row exists
+*/
+func (s *FXService) UpdateExchangeRate(ctx context.Context, input UpdateExchangeRateInput) (ExchangeRate, error) {
+	if input.RateID <= 0 {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "rate_id must be greater than 0")
+	}
+	if input.RateValue != nil && *input.RateValue == "" {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "rate_value is required")
+	}
+	if input.SourceCurrencyID != nil && *input.SourceCurrencyID <= 0 {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "source_currency_id must be greater than 0")
+	}
+	if input.DestinationCurrencyID != nil && *input.DestinationCurrencyID <= 0 {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "destination_currency_id must be greater than 0")
+	}
+	if input.SourceID != nil && *input.SourceID <= 0 {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "source_id must be greater than 0")
+	}
+	if input.TypeID != nil && *input.TypeID <= 0 {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "type_id must be greater than 0")
+	}
+	if input.ValidFromDate != nil && input.ValidFromDate.IsZero() {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "valid_from_date is required")
+	}
+	if input.ValidFromDate != nil && input.ValidToDate != nil && !input.ValidToDate.IsZero() && input.ValidToDate.Before(*input.ValidFromDate) {
+		return ExchangeRate{}, Wrap(nil, ErrInvalidInput.Code, "valid_to_date must be after valid_from_date")
+	}
+
+	rate, err := s.store.UpdateExchangeRate(ctx, db.UpdateExchangeRateParams{
+		RateID:                input.RateID,
+		RateValue:             sql.NullString{String: util.Value(input.RateValue), Valid: input.RateValue != nil},
+		SourceCurrencyID:      sql.NullInt32{Int32: util.Value(input.SourceCurrencyID), Valid: input.SourceCurrencyID != nil},
+		DestinationCurrencyID: sql.NullInt32{Int32: util.Value(input.DestinationCurrencyID), Valid: input.DestinationCurrencyID != nil},
+		ValidFromDate:         sql.NullTime{Time: util.Value(input.ValidFromDate), Valid: input.ValidFromDate != nil},
+		ValidToDate:           sql.NullTime{Time: util.Value(input.ValidToDate), Valid: input.ValidToDate != nil},
+		SourceID:              sql.NullInt32{Int32: util.Value(input.SourceID), Valid: input.SourceID != nil},
+		TypeID:                sql.NullInt32{Int32: util.Value(input.TypeID), Valid: input.TypeID != nil},
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ExchangeRate{}, Wrap(err, ErrNotFound.Code, "exchange rate not found")
+		}
+		return ExchangeRate{}, wrapExchangeRateDBError(err, "failed to update exchange rate")
+	}
+
+	return NewExchangeRate(rate), nil
+}
+
+/*
+DeleteExchangeRate Service is responsible for deleting an exchange rate by ID.
+- Validate rate_id > 0
+- Call store.DeleteExchangeRate
+- Convert DB errors to service errors
+*/
+func (s *FXService) DeleteExchangeRate(ctx context.Context, input DeleteExchangeRateInput) error {
+	if input.RateID <= 0 {
+		return Wrap(nil, ErrInvalidInput.Code, "rate_id must be greater than 0")
+	}
+
+	if err := s.store.DeleteExchangeRate(ctx, input.RateID); err != nil {
+		return Wrap(err, ErrInternal.Code, "failed to delete exchange rate")
+	}
+
+	return nil
+}
+
+/*
+GetHistoricalData Service is responsible for fetching sampled historical FX data.
+- Validate currency/source/type IDs
+- Normalize data point count to API bounds
+- Convert the requested time range into a repository start date
+*/
+func (s *FXService) GetHistoricalData(ctx context.Context, input GetHistoricalDataInput) ([]HistoricalDataPoint, error) {
+	if input.SourceCurrencyID <= 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "source_currency_id must be greater than 0")
+	}
+	if input.DestinationCurrencyID <= 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "destination_currency_id must be greater than 0")
+	}
+	if input.SourceID <= 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "source_id must be greater than 0")
+	}
+	if input.TypeID <= 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "type_id must be greater than 0")
+	}
+
+	dataPoints := input.DataPoints
+	if dataPoints == 0 {
+		dataPoints = 50
+	}
+	if dataPoints > 500 {
+		dataPoints = 500
+	}
+	if dataPoints < 0 {
+		return nil, Wrap(nil, ErrInvalidInput.Code, "data_points must be greater than or equal to 0")
+	}
+
+	duration, err := util.ParseTimeRangeToDuration(input.TimeRange)
+	if err != nil {
+		return nil, Wrap(err, ErrInvalidInput.Code, err.Error())
+	}
+
+	rows, err := s.store.GetHistoricalData(ctx, db.GetHistoricalDataParams{
+		SourceCurrencyID:      input.SourceCurrencyID,
+		DestinationCurrencyID: input.DestinationCurrencyID,
+		SourceID:              sql.NullInt32{Int32: input.SourceID, Valid: true},
+		UpdatedAt:             sql.NullTime{Time: time.Now().Add(-duration), Valid: true},
+		TypeID:                sql.NullInt32{Int32: input.TypeID, Valid: true},
+		Ntile:                 dataPoints,
+	})
+	if err != nil {
+		return nil, Wrap(err, ErrInternal.Code, "failed to get historical exchange rates")
+	}
+
+	res := make([]HistoricalDataPoint, len(rows))
+	for i, row := range rows {
+		res[i] = NewHistoricalDataPoint(row)
+	}
+	return res, nil
+}
+
+func validateExchangeRateValues(rateValue string, sourceCurrencyID, destinationCurrencyID int32, validFromDate, validToDate time.Time) error {
+	if rateValue == "" {
+		return Wrap(nil, ErrInvalidInput.Code, "rate_value is required")
+	}
+	if sourceCurrencyID <= 0 {
+		return Wrap(nil, ErrInvalidInput.Code, "source_currency_id must be greater than 0")
+	}
+	if destinationCurrencyID <= 0 {
+		return Wrap(nil, ErrInvalidInput.Code, "destination_currency_id must be greater than 0")
+	}
+	if validFromDate.IsZero() {
+		return Wrap(nil, ErrInvalidInput.Code, "valid_from_date is required")
+	}
+	if !validToDate.IsZero() && validToDate.Before(validFromDate) {
+		return Wrap(nil, ErrInvalidInput.Code, "valid_to_date must be after valid_from_date")
+	}
+	return nil
+}
+
+func wrapExchangeRateDBError(err error, defaultMessage string) error {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		switch pqErr.Code {
+		case "23505":
+			return Wrap(err, ErrDuplicateExchangeRate.Code, ErrDuplicateExchangeRate.Message)
+		case "23503":
+			return Wrap(err, ErrInvalidInput.Code, "invalid reference id")
+		}
+	}
+	return Wrap(err, ErrInternal.Code, defaultMessage)
+}

--- a/rate-pulse-api/service/fx_test.go
+++ b/rate-pulse-api/service/fx_test.go
@@ -1,0 +1,421 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFXService(t *testing.T) (*FXService, sqlmock.Sqlmock) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	return NewFXService(db.NewStore(sqlDB)), mock
+}
+
+func requireFXServiceErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	require.Error(t, err)
+	require.True(t, IsServiceError(err), "expected service error, got %T: %v", err, err)
+	require.Equal(t, code, ServiceErrorCode(err))
+}
+
+func testExchangeRateForFXService() db.ExchangeRate {
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	return db.ExchangeRate{
+		RateID:                42,
+		RateValue:             "17695.08",
+		SourceCurrencyID:      1,
+		DestinationCurrencyID: 2,
+		ValidFromDate:         now,
+		ValidToDate:           sql.NullTime{Time: now.Add(24 * time.Hour), Valid: true},
+		SourceID:              sql.NullInt32{Int32: 10, Valid: true},
+		TypeID:                sql.NullInt32{Int32: 1, Valid: true},
+		CreatedAt:             sql.NullTime{Time: now, Valid: true},
+		UpdatedAt:             sql.NullTime{Time: now, Valid: true},
+	}
+}
+
+func exchangeRateRows(rates ...db.ExchangeRate) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{
+		"rate_id",
+		"rate_value",
+		"source_currency_id",
+		"destination_currency_id",
+		"valid_from_date",
+		"valid_to_date",
+		"source_id",
+		"updated_at",
+		"created_at",
+		"type_id",
+	})
+
+	for _, rate := range rates {
+		rows.AddRow(
+			rate.RateID,
+			rate.RateValue,
+			rate.SourceCurrencyID,
+			rate.DestinationCurrencyID,
+			rate.ValidFromDate,
+			rate.ValidToDate,
+			rate.SourceID,
+			rate.UpdatedAt,
+			rate.CreatedAt,
+			rate.TypeID,
+		)
+	}
+
+	return rows
+}
+
+func exchangeRateGetRows(rates ...db.ExchangeRate) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{
+		"rate_id",
+		"rate_value",
+		"source_currency_id",
+		"destination_currency_id",
+		"valid_from_date",
+		"valid_to_date",
+		"source_id",
+		"type_id",
+		"created_at",
+		"updated_at",
+	})
+
+	for _, rate := range rates {
+		rows.AddRow(
+			rate.RateID,
+			rate.RateValue,
+			rate.SourceCurrencyID,
+			rate.DestinationCurrencyID,
+			rate.ValidFromDate,
+			rate.ValidToDate,
+			rate.SourceID,
+			rate.TypeID,
+			rate.CreatedAt,
+			rate.UpdatedAt,
+		)
+	}
+
+	return rows
+}
+
+func TestFXServiceCreateExchangeRateInvalidInput(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	rate, err := fxService.CreateExchangeRate(context.Background(), CreateExchangeRateInput{
+		RateValue:             "",
+		SourceCurrencyID:      1,
+		DestinationCurrencyID: 2,
+		ValidFromDate:         time.Now(),
+	})
+
+	requireFXServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Empty(t, rate)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceCreateExchangeRateDuplicate(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	now := time.Now()
+	mock.ExpectQuery("INSERT INTO exchange_rates").
+		WillReturnError(&pq.Error{Code: "23505", Message: "duplicate key value violates unique constraint"})
+
+	rate, err := fxService.CreateExchangeRate(context.Background(), CreateExchangeRateInput{
+		RateValue:             "17695.08",
+		SourceCurrencyID:      1,
+		DestinationCurrencyID: 2,
+		ValidFromDate:         now,
+		SourceID:              10,
+		TypeID:                1,
+	})
+
+	requireFXServiceErrorCode(t, err, ErrDuplicateExchangeRate.Code)
+	require.Empty(t, rate)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceCreateExchangeRateSuccess(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+	dbRate := testExchangeRateForFXService()
+
+	mock.ExpectQuery("INSERT INTO exchange_rates").
+		WithArgs(
+			dbRate.RateValue,
+			dbRate.SourceCurrencyID,
+			dbRate.DestinationCurrencyID,
+			dbRate.ValidFromDate,
+			dbRate.ValidToDate,
+			dbRate.SourceID,
+			dbRate.TypeID,
+		).
+		WillReturnRows(exchangeRateRows(dbRate))
+
+	rate, err := fxService.CreateExchangeRate(context.Background(), CreateExchangeRateInput{
+		RateValue:             dbRate.RateValue,
+		SourceCurrencyID:      dbRate.SourceCurrencyID,
+		DestinationCurrencyID: dbRate.DestinationCurrencyID,
+		ValidFromDate:         dbRate.ValidFromDate,
+		ValidToDate:           dbRate.ValidToDate.Time,
+		SourceID:              dbRate.SourceID.Int32,
+		TypeID:                dbRate.TypeID.Int32,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, dbRate.RateID, rate.RateID)
+	require.Equal(t, dbRate.RateValue, rate.RateValue)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceGetExchangeRateInvalidID(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	rate, err := fxService.GetExchangeRate(context.Background(), GetExchangeRateInput{RateID: 0})
+
+	requireFXServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Empty(t, rate)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceGetExchangeRateNotFound(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	mock.ExpectQuery("SELECT rate_id, rate_value").
+		WithArgs(int32(404)).
+		WillReturnError(sql.ErrNoRows)
+
+	rate, err := fxService.GetExchangeRate(context.Background(), GetExchangeRateInput{RateID: 404})
+
+	requireFXServiceErrorCode(t, err, ErrNotFound.Code)
+	require.Empty(t, rate)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceGetExchangeRateSuccess(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+	dbRate := testExchangeRateForFXService()
+
+	mock.ExpectQuery("SELECT rate_id, rate_value").
+		WithArgs(dbRate.RateID).
+		WillReturnRows(exchangeRateGetRows(dbRate))
+
+	rate, err := fxService.GetExchangeRate(context.Background(), GetExchangeRateInput{RateID: dbRate.RateID})
+
+	require.NoError(t, err)
+	require.Equal(t, dbRate.RateID, rate.RateID)
+	require.Equal(t, dbRate.SourceID.Int32, rate.SourceID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceListLatestExchangeRatesInvalidLimit(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	rates, err := fxService.ListLatestExchangeRates(context.Background(), ListLatestExchangeRatesInput{
+		SourceCurrencyID: 1,
+		Limit:            1001,
+	})
+
+	requireFXServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Nil(t, rates)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceListLatestExchangeRatesSuccess(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT DISTINCT ON").
+		WithArgs(int32(1), int32(20)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"rate_id",
+			"rate_value",
+			"source_currency_code",
+			"destination_currency_code",
+			"valid_from_date",
+			"rate_source_code",
+			"type_name",
+			"updated_at",
+		}).AddRow(
+			42,
+			"17695.08",
+			"AUD",
+			"VND",
+			now,
+			sql.NullString{String: "VCB", Valid: true},
+			sql.NullString{String: "Buy Cash", Valid: true},
+			sql.NullTime{Time: now, Valid: true},
+		))
+
+	rates, err := fxService.ListLatestExchangeRates(context.Background(), ListLatestExchangeRatesInput{
+		SourceCurrencyID: 1,
+		Limit:            20,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+	require.Equal(t, "AUD", rates[0].SourceCurrencyCode)
+	require.Equal(t, "VCB", rates[0].RateSourceCode)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceUpdateExchangeRateNotFound(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	rateValue := "18000.00"
+	mock.ExpectQuery("UPDATE exchange_rates").
+		WithArgs(
+			int32(42),
+			sql.NullString{String: rateValue, Valid: true},
+			sql.NullInt32{},
+			sql.NullInt32{},
+			sql.NullTime{},
+			sql.NullTime{},
+			sql.NullInt32{},
+			sql.NullInt32{},
+		).
+		WillReturnError(sql.ErrNoRows)
+
+	rate, err := fxService.UpdateExchangeRate(context.Background(), UpdateExchangeRateInput{
+		RateID:    42,
+		RateValue: &rateValue,
+	})
+
+	requireFXServiceErrorCode(t, err, ErrNotFound.Code)
+	require.Empty(t, rate)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceUpdateExchangeRateSuccess(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	rateValue := "18000.00"
+	updatedRate := testExchangeRateForFXService()
+	updatedRate.RateValue = rateValue
+
+	mock.ExpectQuery("UPDATE exchange_rates").
+		WithArgs(
+			updatedRate.RateID,
+			sql.NullString{String: rateValue, Valid: true},
+			sql.NullInt32{},
+			sql.NullInt32{},
+			sql.NullTime{},
+			sql.NullTime{},
+			sql.NullInt32{},
+			sql.NullInt32{},
+		).
+		WillReturnRows(exchangeRateRows(updatedRate))
+
+	rate, err := fxService.UpdateExchangeRate(context.Background(), UpdateExchangeRateInput{
+		RateID:    updatedRate.RateID,
+		RateValue: &rateValue,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, rateValue, rate.RateValue)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceDeleteExchangeRateInvalidID(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	err := fxService.DeleteExchangeRate(context.Background(), DeleteExchangeRateInput{RateID: 0})
+
+	requireFXServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceDeleteExchangeRateDBError(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	mock.ExpectExec("DELETE FROM exchange_rates").
+		WithArgs(int32(42)).
+		WillReturnError(errors.New("database unavailable"))
+
+	err := fxService.DeleteExchangeRate(context.Background(), DeleteExchangeRateInput{RateID: 42})
+
+	requireFXServiceErrorCode(t, err, ErrInternal.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceDeleteExchangeRateSuccess(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	mock.ExpectExec("DELETE FROM exchange_rates").
+		WithArgs(int32(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := fxService.DeleteExchangeRate(context.Background(), DeleteExchangeRateInput{RateID: 42})
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceGetHistoricalDataInvalidTimeRange(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+
+	points, err := fxService.GetHistoricalData(context.Background(), GetHistoricalDataInput{
+		SourceCurrencyID:      1,
+		DestinationCurrencyID: 2,
+		SourceID:              10,
+		TypeID:                1,
+		TimeRange:             "bad",
+	})
+
+	requireFXServiceErrorCode(t, err, ErrInvalidInput.Code)
+	require.Nil(t, points)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFXServiceGetHistoricalDataSuccess(t *testing.T) {
+	fxService, mock := newTestFXService(t)
+	now := time.Now()
+
+	mock.ExpectQuery("WITH bucketed AS").
+		WithArgs(
+			int32(1),
+			int32(2),
+			sql.NullInt32{Int32: 10, Valid: true},
+			sqlmock.AnyArg(),
+			sql.NullInt32{Int32: 1, Valid: true},
+			int32(50),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"rate_value",
+			"updated_at",
+			"type_id",
+		}).AddRow(
+			"17695.08",
+			sql.NullTime{Time: now, Valid: true},
+			sql.NullInt32{Int32: 1, Valid: true},
+		))
+
+	points, err := fxService.GetHistoricalData(context.Background(), GetHistoricalDataInput{
+		SourceCurrencyID:      1,
+		DestinationCurrencyID: 2,
+		SourceID:              10,
+		TypeID:                1,
+		TimeRange:             "24h",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	require.Equal(t, "17695.08", points[0].RateValue)
+	require.Equal(t, int32(1), points[0].TypeID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/rate-pulse-api/service/helpers.go
+++ b/rate-pulse-api/service/helpers.go
@@ -23,3 +23,57 @@ func NewUser(user db.User) User {
 		UpdatedAt:          user.UpdatedAt.Time,
 	}
 }
+
+/*
+	Helper function to create a new ExchangeRate from a db.ExchangeRate.
+*/
+func NewExchangeRate(rate db.ExchangeRate) ExchangeRate {
+	return ExchangeRate{
+		RateID:                rate.RateID,
+		RateValue:             rate.RateValue,
+		SourceCurrencyID:      rate.SourceCurrencyID,
+		DestinationCurrencyID: rate.DestinationCurrencyID,
+		ValidFromDate:         rate.ValidFromDate,
+		ValidToDate:           rate.ValidToDate.Time,
+		SourceID:              rate.SourceID.Int32,
+		TypeID:                rate.TypeID.Int32,
+		CreatedAt:             rate.CreatedAt.Time,
+		UpdatedAt:             rate.UpdatedAt.Time,
+	}
+}
+
+func NewExchangeRateFromGetRow(rate db.GetExchangeRateByIDRow) ExchangeRate {
+	return ExchangeRate{
+		RateID:                rate.RateID,
+		RateValue:             rate.RateValue,
+		SourceCurrencyID:      rate.SourceCurrencyID,
+		DestinationCurrencyID: rate.DestinationCurrencyID,
+		ValidFromDate:         rate.ValidFromDate,
+		ValidToDate:           rate.ValidToDate.Time,
+		SourceID:              rate.SourceID.Int32,
+		TypeID:                rate.TypeID.Int32,
+		CreatedAt:             rate.CreatedAt.Time,
+		UpdatedAt:             rate.UpdatedAt.Time,
+	}
+}
+
+func NewLatestExchangeRate(rate db.GetAllExchangeRatesTodayNormalisedRow) LatestExchangeRate {
+	return LatestExchangeRate{
+		RateID:                  rate.RateID,
+		RateValue:               rate.RateValue,
+		SourceCurrencyCode:      rate.SourceCurrencyCode,
+		DestinationCurrencyCode: rate.DestinationCurrencyCode,
+		ValidFromDate:           rate.ValidFromDate,
+		RateSourceCode:          rate.RateSourceCode.String,
+		TypeName:                rate.TypeName.String,
+		UpdatedAt:               rate.UpdatedAt.Time,
+	}
+}
+
+func NewHistoricalDataPoint(point db.GetHistoricalDataRow) HistoricalDataPoint {
+	return HistoricalDataPoint{
+		RateValue: point.RateValue,
+		UpdatedAt: point.UpdatedAt.Time,
+		TypeID:    point.TypeID.Int32,
+	}
+}

--- a/rate-pulse-api/service/models.go
+++ b/rate-pulse-api/service/models.go
@@ -107,3 +107,79 @@ type AdminUpdateUserInput struct {
 type DeleteUserInput struct {
 	UserID int32
 }
+
+/*
+fx service models
+*/
+type ExchangeRate struct {
+	RateID                int32
+	RateValue             string
+	SourceCurrencyID      int32
+	DestinationCurrencyID int32
+	ValidFromDate         time.Time
+	ValidToDate           time.Time
+	SourceID              int32
+	TypeID                int32
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}
+
+type LatestExchangeRate struct {
+	RateID                  int32
+	RateValue               string
+	SourceCurrencyCode      string
+	DestinationCurrencyCode string
+	ValidFromDate           time.Time
+	RateSourceCode          string
+	TypeName                string
+	UpdatedAt               time.Time
+}
+
+type HistoricalDataPoint struct {
+	RateValue string
+	UpdatedAt time.Time
+	TypeID    int32
+}
+
+type CreateExchangeRateInput struct {
+	RateValue             string
+	SourceCurrencyID      int32
+	DestinationCurrencyID int32
+	ValidFromDate         time.Time
+	ValidToDate           time.Time
+	SourceID              int32
+	TypeID                int32
+}
+
+type GetExchangeRateInput struct {
+	RateID int32
+}
+
+type ListLatestExchangeRatesInput struct {
+	SourceCurrencyID int32
+	Limit            int32
+}
+
+type UpdateExchangeRateInput struct {
+	RateID                int32
+	RateValue             *string
+	SourceCurrencyID      *int32
+	DestinationCurrencyID *int32
+	ValidFromDate         *time.Time
+	ValidToDate           *time.Time
+	SourceID              *int32
+	TypeID                *int32
+}
+
+type DeleteExchangeRateInput struct {
+	RateID int32
+}
+
+type GetHistoricalDataInput struct {
+	SourceCurrencyID      int32
+	DestinationCurrencyID int32
+	SourceID              int32
+	TypeID                int32
+	TimeRange             string
+	DataPoints            int32
+}

--- a/rate-pulse-api/service/service.go
+++ b/rate-pulse-api/service/service.go
@@ -10,11 +10,13 @@ import (
 type Services struct {
 	Auth  *AuthService
 	Users *UserService
+	FX    *FXService
 }
 
 func NewServices(config util.Config, store *db.Store, tokenMaker token.Maker) *Services {
 	return &Services{
 		Auth:  NewAuthService(config, store, tokenMaker),
 		Users: NewUserService(store),
+		FX:    NewFXService(store),
 	}
 }


### PR DESCRIPTION
Added:

- New FXService with use cases for creating, reading, updating, and deleting exchange rates, listing latest normalized rates (GetAllExchangeRatesTodayNormalised), and historical sampled data (GetHistoricalData), including validation and consistent error mapping (including PostgreSQL duplicate / FK-style failures where applicable).
- Centrailised errors printing into errors.go in api folder
- Tests: service/fx_test.go covers validation, success paths, not-found, duplicate constraint handling, and historical query wiring.