### PR TITLE
Feat: Implemented Rate Limit To Redis

### DIFF
--- a/client/src/components/dashboard/HistoricalClient.tsx
+++ b/client/src/components/dashboard/HistoricalClient.tsx
@@ -90,6 +90,7 @@ function formatChartLabel(iso: string, timeRange: (typeof TIME_RANGES)[number]):
 
   return date.toLocaleDateString("en-GB", {
     timeZone: "Asia/Ho_Chi_Minh",
+    day: "2-digit",
     month: "short",
     year: "2-digit",
   });

--- a/rate-pulse-api/api/ratelimit_middleware.go
+++ b/rate-pulse-api/api/ratelimit_middleware.go
@@ -2,10 +2,8 @@ package api
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,10 +15,10 @@ func (server *Server) rateLimitMiddleware() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		// Determine the identifier: user ID if authenticated, otherwise IP
 		var identifier string
-		if userID, exists := ctx.Get("user_id"); exists {
-			identifier = fmt.Sprintf("user:%v", userID)
+		if payload, ok := authPayloadFromGinContext(ctx); ok {
+			identifier = fmt.Sprintf("user:%d", payload.UserID)
 		} else {
-			identifier = getClientIP(ctx)
+			identifier = ctx.ClientIP()
 		}
 
 		if identifier == "" {
@@ -51,28 +49,4 @@ func (server *Server) rateLimitMiddleware() gin.HandlerFunc {
 
 		ctx.Next()
 	}
-}
-
-// getClientIP extracts the real client IP address
-// Handles X-Forwarded-For, X-Real-IP headers for proxied requests
-func getClientIP(ctx *gin.Context) string {
-	// Check X-Forwarded-For header (multiple proxies)
-	if xff := ctx.GetHeader("X-Forwarded-For"); xff != "" {
-		ips := strings.Split(xff, ",")
-		if ip := strings.TrimSpace(ips[0]); ip != "" {
-			return ip
-		}
-	}
-
-	// Check X-Real-IP header
-	if xri := ctx.GetHeader("X-Real-IP"); xri != "" {
-		return xri
-	}
-
-	// Fall back to RemoteAddr
-	ip, _, err := net.SplitHostPort(ctx.Request.RemoteAddr)
-	if err != nil {
-		return ctx.Request.RemoteAddr
-	}
-	return ip
 }

--- a/rate-pulse-api/api/ratelimit_middleware.go
+++ b/rate-pulse-api/api/ratelimit_middleware.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// rateLimitMiddleware enforces rate limiting on all requests
+// Uses IP address for public requests, user ID for authenticated requests
+func (server *Server) rateLimitMiddleware() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		// Determine the identifier: user ID if authenticated, otherwise IP
+		var identifier string
+		if userID, exists := ctx.Get("user_id"); exists {
+			identifier = fmt.Sprintf("user:%v", userID)
+		} else {
+			identifier = getClientIP(ctx)
+		}
+
+		if identifier == "" {
+			ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Unable to identify client"})
+			return
+		}
+
+		// Check rate limit
+		allowed, remaining, resetTime := server.rateLimiter.Allow(ctx, identifier)
+
+		// Add rate limit headers to response
+		ctx.Header("X-RateLimit-Limit", strconv.Itoa(server.config.RateLimitPerMinute))
+		ctx.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+		ctx.Header("X-RateLimit-Reset", strconv.FormatInt(resetTime, 10))
+
+		if !allowed {
+			retryAfter := resetTime - time.Now().Unix()
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
+			ctx.Header("Retry-After", strconv.FormatInt(retryAfter, 10))
+			ctx.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error":   "rate limit exceeded",
+				"message": fmt.Sprintf("Too many requests. Please retry after %d seconds.", retryAfter),
+			})
+			return
+		}
+
+		ctx.Next()
+	}
+}
+
+// getClientIP extracts the real client IP address
+// Handles X-Forwarded-For, X-Real-IP headers for proxied requests
+func getClientIP(ctx *gin.Context) string {
+	// Check X-Forwarded-For header (multiple proxies)
+	if xff := ctx.GetHeader("X-Forwarded-For"); xff != "" {
+		ips := strings.Split(xff, ",")
+		if ip := strings.TrimSpace(ips[0]); ip != "" {
+			return ip
+		}
+	}
+
+	// Check X-Real-IP header
+	if xri := ctx.GetHeader("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	// Fall back to RemoteAddr
+	ip, _, err := net.SplitHostPort(ctx.Request.RemoteAddr)
+	if err != nil {
+		return ctx.Request.RemoteAddr
+	}
+	return ip
+}

--- a/rate-pulse-api/api/server.go
+++ b/rate-pulse-api/api/server.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/ThanhVinhTong/rate-pulse/cache"
 	db "github.com/ThanhVinhTong/rate-pulse/db/sqlc"
+	"github.com/ThanhVinhTong/rate-pulse/ratelimit"
 	"github.com/ThanhVinhTong/rate-pulse/service"
 	"github.com/ThanhVinhTong/rate-pulse/token"
 	"github.com/ThanhVinhTong/rate-pulse/util"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 )
 
 // Serve all HTTP requests for our rate pulse service
@@ -20,6 +22,7 @@ type Server struct {
 	tokenMaker    token.Maker
 	services      *service.Services
 	responseCache cache.ResponseCache
+	rateLimiter   *ratelimit.RateLimiter
 	router        *gin.Engine
 }
 
@@ -28,13 +31,21 @@ func NewServer(
 	store db.Store,
 	services *service.Services,
 	tokenMaker token.Maker,
+	redisClient *redis.Client,
 ) (*Server, error) {
+	// Initialize rate limiter with default 300 req/min if not configured
+	requestsPerMin := config.RateLimitPerMinute
+	if requestsPerMin <= 0 {
+		requestsPerMin = 300
+	}
+
 	server := &Server{
 		config:        config,
 		store:         store,
 		tokenMaker:    tokenMaker,
 		services:      services,
 		responseCache: cache.NoopResponseCache{},
+		rateLimiter:   ratelimit.NewRateLimiter(redisClient, requestsPerMin),
 	}
 
 	server.setupRouter()
@@ -54,6 +65,7 @@ func (server *Server) setupRouter() {
 	router.Use(ginRecovery())
 	router.Use(requestIDMiddleware())
 	router.Use(ginLogger())
+	router.Use(server.rateLimitMiddleware())
 	if err := router.SetTrustedProxies(nil); err != nil {
 		return
 	}

--- a/rate-pulse-api/cache/redis.go
+++ b/rate-pulse-api/cache/redis.go
@@ -16,6 +16,24 @@ type RedisResponseCache struct {
 	client *redis.Client
 }
 
+// NewRedisClient creates a Redis client for general use (e.g., rate limiting)
+func NewRedisClient(config util.Config) (*redis.Client, error) {
+	if strings.TrimSpace(config.RedisAddress) == "" {
+		return nil, errors.New("REDIS_ADDRESS is required")
+	}
+
+	opt := &redis.Options{
+		Addr:     strings.TrimSpace(config.RedisAddress),
+		Username: strings.TrimSpace(config.RedisUsername),
+		Password: config.RedisPassword,
+	}
+	if config.RedisTLS {
+		opt.TLSConfig = redisTLSConfig(opt.Addr)
+	}
+
+	return redis.NewClient(opt), nil
+}
+
 func NewRedisResponseCache(config util.Config) (*RedisResponseCache, error) {
 	if strings.TrimSpace(config.RedisAddress) == "" {
 		return nil, errors.New("REDIS_ADDRESS is required")

--- a/rate-pulse-api/main.go
+++ b/rate-pulse-api/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/hibiken/asynq"
 	_ "github.com/lib/pq"
+	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
@@ -67,6 +68,12 @@ func main() {
 		log.Fatal().Err(err).Msg("Cannot configure response cache")
 	}
 
+	// Create a Redis client for rate limiting
+	redisClient, err := responsecache.NewRedisClient(config)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Cannot configure Redis client for rate limiting")
+	}
+
 	// Create token maker for both gRPC and HTTP servers
 	tokenMaker, err := token.NewPasetoMaker(config.TokenSymmetricKey)
 	if err != nil {
@@ -90,7 +97,7 @@ func main() {
 	// Start Task Processor and gRPC server in separate goroutines, while the main goroutine runs the HTTP server.
 	go runTaskProcessor(config, redisOpt, store, emailSender)
 	go runGrpcServer(config, services, tokenMaker)
-	runGinServer(config, store, services, tokenMaker, responseCache)
+	runGinServer(config, store, services, tokenMaker, responseCache, redisClient)
 }
 
 func runGinServer(
@@ -99,8 +106,9 @@ func runGinServer(
 	services *service.Services,
 	tokenMaker token.Maker,
 	responseCache responsecache.ResponseCache,
+	redisClient *redis.Client,
 ) {
-	server, err := api.NewServer(config, store, services, tokenMaker)
+	server, err := api.NewServer(config, store, services, tokenMaker, redisClient)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Cannot create server")
 	}

--- a/rate-pulse-api/ratelimit/limiter.go
+++ b/rate-pulse-api/ratelimit/limiter.go
@@ -1,0 +1,82 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RateLimiter implements token bucket algorithm for rate limiting using Redis
+type RateLimiter struct {
+	client         *redis.Client
+	requestsPerMin int
+}
+
+// NewRateLimiter creates a new rate limiter with Redis backend
+func NewRateLimiter(redisClient *redis.Client, requestsPerMin int) *RateLimiter {
+	return &RateLimiter{
+		client:         redisClient,
+		requestsPerMin: requestsPerMin,
+	}
+}
+
+// Allow checks if a request from the given key is allowed
+// Returns (allowed bool, remaining int, resetTime int64)
+func (rl *RateLimiter) Allow(ctx context.Context, key string) (bool, int, int64) {
+	// Ensure key is valid
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return false, 0, 0
+	}
+
+	redisKey := fmt.Sprintf("ratelimit:%s", key)
+
+	now := time.Now().Unix()
+	windowStart := now - 60 // 1 minute window
+
+	// Lua script to atomically check and increment rate limit counter
+	script := redis.NewScript(`
+		local key = KEYS[1]
+		local limit = tonumber(ARGV[1])
+		local now = tonumber(ARGV[2])
+		local window_start = tonumber(ARGV[3])
+		
+		-- Remove old entries outside the window
+		redis.call('ZREMRANGEBYSCORE', key, '-inf', window_start)
+		
+		-- Count requests in the current window
+		local current = redis.call('ZCARD', key)
+		
+		-- Check if limit exceeded
+		if current < limit then
+			-- Add current request with timestamp as score
+			redis.call('ZADD', key, now, now)
+			-- Set expiration to 2 minutes to clean up old data
+			redis.call('EXPIRE', key, 120)
+			-- Return: allowed, remaining, reset_time
+			return {1, limit - current - 1, now + 60}
+		else
+			-- Get the oldest request timestamp for reset time calculation
+			local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+			local reset_time = oldest[2] and (tonumber(oldest[2]) + 60) or (now + 60)
+			return {0, 0, reset_time}
+		end
+	`)
+
+	result, err := script.Run(ctx, rl.client, []string{redisKey}, rl.requestsPerMin, now, windowStart).Result()
+	if err != nil {
+		// On error, fail open (allow the request) but log it
+		// In production, you might want to fail closed instead
+		return true, rl.requestsPerMin, now + 60
+	}
+
+	values := result.([]interface{})
+	allowed := values[0].(int64) == 1
+	remaining := int(values[1].(int64))
+	resetTime := values[2].(int64)
+
+	return allowed, remaining, resetTime
+}

--- a/rate-pulse-api/util/config.go
+++ b/rate-pulse-api/util/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	EmailSenderAddress     string        `mapstructure:"EMAIL_SENDER_ADDRESS"`
 	EmailSenderPassword    string        `mapstructure:"EMAIL_SENDER_PASSWORD"`
 	FrontendVerifyEmailURL string        `mapstructure:"FRONTEND_VERIFY_EMAIL_URL"`
+	RateLimitPerMinute     int           `mapstructure:"RATE_LIMIT_PER_MINUTE"`
 }
 
 // LoadConfig loads the configuration from the environment variables
@@ -49,6 +50,7 @@ func LoadConfig(path string) (config Config, err error) {
 	viper.BindEnv("EMAIL_SENDER_ADDRESS")
 	viper.BindEnv("EMAIL_SENDER_PASSWORD")
 	viper.BindEnv("FRONTEND_VERIFY_EMAIL_URL")
+	viper.BindEnv("RATE_LIMIT_PER_MINUTE")
 
 	err = viper.ReadInConfig()
 	if err != nil {


### PR DESCRIPTION
# What I did in this PR:
- Fix a bug where if time range > 1M, the date get generalize
- Implement rate limit to Redis (default 300 req/min) changeable by adding RATE_LIMIT_PER_MINUTE to app.env
- It will be enforced by IP for public API and user_id for authenticated API

# Evidence:
<img width="505" height="383" alt="image" src="https://github.com/user-attachments/assets/1471e4f0-330d-44d9-9f28-80ded8a49beb" />
