### PR TITLE
fix: duplicate driver.quit()

### DIFF
--- a/pulse_intel/news/wms.py
+++ b/pulse_intel/news/wms.py
@@ -109,7 +109,4 @@ class WMS(Scraper):
         # Fetch financial news
         self.news_data["financial"] = self.get_feed_news(ids["financial"])
 
-        print("Quitting driver")
-        self.driver.quit()
-
         return self.news_data


### PR DESCRIPTION
Current script returns warning log to email. 
Reason: duplicate driver.quit() call, making the system returns warning
Change: delete duplicate driver.quit() in `wms.py`