### PR TITLE
Feature: Worker to help your life easier

### DIFF
--- a/.github/workflows/daily_worker.yml
+++ b/.github/workflows/daily_worker.yml
@@ -1,0 +1,44 @@
+# Scheduled news sync & retention worker (pulse_intel) on GitHub-hosted runners.
+
+name: pulse_intel daily sync and prune worker
+
+on:
+  schedule:
+    # Daily at 03:00 AM UTC (off-peak hours)
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  run_worker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    defaults:
+      run:
+        working-directory: pulse_intel
+
+    env:
+      MONGO_URI: ${{ secrets.MONGO_URI }}
+      MONGO_DB: ${{ secrets.MONGO_DB }}
+      MONGO_COLLECTION: ${{ secrets.MONGO_COLLECTION }}
+      MONGO_WEEKLY_URI: ${{ secrets.MONGO_WEEKLY_URI }}
+      MONGO_WEEKLY_DB: ${{ secrets.MONGO_WEEKLY_DB }}
+      MONGO_WEEKLY_COLLECTION: ${{ secrets.MONGO_WEEKLY_COLLECTION }}
+      GMAIL_SMTP_USER_INTEL: ${{ secrets.GMAIL_SMTP_USER_INTEL }}
+      GMAIL_APP_PASSWORD_INTEL: ${{ secrets.GMAIL_APP_PASSWORD_INTEL }}
+      GMAIL_NOTIFY_TO_INTEL: ${{ secrets.GMAIL_NOTIFY_TO_INTEL }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pulse_intel worker
+        run: python worker.py

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ npm run build   # production build
 npm run lint    # ESLint
 ```
 
+**Note:** Make sure you config client/.env before running your frontend with the following variables:
+```
+MONGO_URI=
+MONGO_DB=
+MONGO_COLLECTION=
+RATE_PULSE_API_BASE_URL=
+```
+
 ## API overview
 
 ### Public
@@ -195,13 +203,24 @@ pulse-intel/
 
 Additional IDs exist for expansion (economic indicators, trade, supply chain, financial, technology, crypto, AI/ML, etc.).
 
-### Run
+### Setup & Environment
 
-```bash
-cd pulse-intel
-pip install -r requirements.txt
-python main.py
-```
+1. Copy `.env.example` to `.env` inside `pulse-intel/`:
+   ```bash
+   cp pulse-intel/.env.example pulse-intel/.env
+   ```
+2. Configure your MongoDB clusters and Gmail notification credentials in `.env`:
+   - `MONGO_URI`: Primary database cluster for production app queries (keeps a minimum of 10 latest snapshots).
+   - `GMAIL_SMTP_USER`, `GMAIL_APP_PASSWORD`, `GMAIL_NOTIFY_TO`: Credentials for receiving execution log notifications.
+
+### Scraper & Data Worker
+
+- **Run Scraper**: Collects latest market news and exports to MongoDB / Excel.
+  ```bash
+  cd pulse-intel
+  pip install -r requirements.txt
+  python main.py
+  ```
 
 Requires Python 3.10+, Microsoft Edge, and a matching Edge WebDriver.
 

--- a/pulse_intel/.env.example
+++ b/pulse_intel/.env.example
@@ -1,3 +1,12 @@
-MONGO_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/?appName=<appName>
+MONGO_URI=mongodb+srv://<user>:<password>@<prod_cluster>.mongodb.net/?appName=<appName>
 MONGO_DB=rate_pulse
 MONGO_COLLECTION=news-rate-pulse
+
+# Second cluster for storing weekly historical data (min 60 records)
+MONGO_WEEKLY_URI=mongodb+srv://<user>:<password>@<weekly_cluster>.mongodb.net/?appName=<appName>
+MONGO_WEEKLY_DB=rate_pulse
+MONGO_WEEKLY_COLLECTION=news-rate-pulse-weekly
+
+GMAIL_SMTP_USER=
+GMAIL_APP_PASSWORD=
+GMAIL_NOTIFY_TO=

--- a/pulse_intel/README.md
+++ b/pulse_intel/README.md
@@ -137,13 +137,33 @@ output_folder = "./output_news/"
 
 Make sure your Edge WebDriver version matches your installed Edge browser version.
 
-## Run
+Next, environment variables:
 
-Start the scraper with:
+1. Create `.env` from `.env.example`:
+   ```bash
+   cp .env.example .env
+   ```
+2. Configure environmental variables:
+   - `MONGO_URI`: Production cluster URI (retains min 10 records).
+   - `MONGO_WEEKLY_URI`: Weekly historical cluster URI (retains min 60 records).
+   - `GMAIL_SMTP_USER`, `GMAIL_APP_PASSWORD`, `GMAIL_NOTIFY_TO`: SMTP credentials for email log delivery.
 
-```bash
-python main.py
-```
+## Execution
+
+- **Run Scraper**:
+  ```bash
+  python main.py
+  ```
+
+- **Run Worker (Sync & Data Retention)**:
+  ```bash
+  python worker.py
+  ```
+  `worker.py` copies daily scraped documents to the weekly cluster without duplicates, then prunes the oldest records in production (min 10 kept) and weekly history (min 60 kept).
+
+- **Automated Workflow**:
+  Triggered daily at 03:00 UTC via GitHub Actions (`.github/workflows/daily_worker.yml`).
+
 
 ## Output
 

--- a/pulse_intel/worker.py
+++ b/pulse_intel/worker.py
@@ -1,0 +1,111 @@
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pymongo import MongoClient, ASCENDING
+from pymongo.server_api import ServerApi
+
+from utils.cloud_delivery import deliver_run_notifications
+from utils.logging_config import configure_logging
+
+logger = logging.getLogger(__name__)
+
+MIN_PROD_RECORDS = 10
+MIN_WEEKLY_RECORDS = 60
+
+
+def _default_log_path() -> str:
+    base = os.getcwd()
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    return os.path.join(base, "logs", f"pulse_intel_worker_{ts}.log")
+
+
+def prune_collection(collection, min_limit: int, name: str):
+    count = collection.count_documents({})
+    if count <= min_limit:
+        logger.info("[%s] Total documents (%d) <= limit (%d). Skipping deletion.", name, count, min_limit)
+        return
+
+    to_delete_count = count - min_limit
+    oldest_docs = list(collection.find({}, {"_id": 1}).sort("generated_at", ASCENDING).limit(to_delete_count))
+    if oldest_docs:
+        delete_ids = [d["_id"] for d in oldest_docs]
+        res = collection.delete_many({"_id": {"$in": delete_ids}})
+        logger.info("[%s] Deleted %d oldest records. Retained %d records.", name, res.deleted_count, min_limit)
+
+
+def sync_and_prune() -> int:
+    load_dotenv(Path(__file__).parent / ".env")
+
+    log_file = os.getenv("PULSE_INTEL_LOG_FILE", "") or _default_log_path()
+    configure_logging(log_file=log_file)
+    logger.info("Worker process starting...")
+
+    prod_uri = os.environ.get("MONGO_URI", "")
+    prod_db = os.environ.get("MONGO_DB", "rate_pulse")
+    prod_col_name = os.environ.get("MONGO_COLLECTION", "news-rate-pulse")
+
+    weekly_uri = os.environ.get("MONGO_WEEKLY_URI", "")
+    weekly_db = os.environ.get("MONGO_WEEKLY_DB", "rate_pulse")
+    weekly_col_name = os.environ.get("MONGO_WEEKLY_COLLECTION", "news-rate-pulse-weekly")
+
+    if not prod_uri:
+        logger.error("MONGO_URI is not set.")
+        deliver_run_notifications(log_path=log_file, success=False)
+        return 1
+
+    exit_code = 0
+    try:
+        prod_client = MongoClient(prod_uri, server_api=ServerApi("1"))
+        prod_col = prod_client[prod_db][prod_col_name]
+
+        # Determine if a distinct second cluster/URI is configured
+        is_valid_weekly = bool(
+            weekly_uri 
+            and not weekly_uri.startswith("mongodb+srv://<user>") 
+            and "<" not in weekly_uri 
+            and weekly_uri != prod_uri
+        )
+
+        if not is_valid_weekly:
+            logger.info("MONGO_WEEKLY_URI is unconfigured, placeholder, or identical to PROD_URI. Skipping sync to weekly cluster.")
+            prune_collection(prod_col, MIN_PROD_RECORDS, "prod")
+            logger.info("Worker prune completed successfully.")
+            return 0
+
+        weekly_client = MongoClient(weekly_uri, server_api=ServerApi("1"))
+        weekly_col = weekly_client[weekly_db][weekly_col_name]
+
+        prod_docs = list(prod_col.find({}, {"_id": 1, "generated_at": 1}))
+        if not prod_docs:
+            logger.info("No documents found in prod collection.")
+        else:
+            logger.info("Found %d documents in prod collection.", len(prod_docs))
+            existing_weekly_ids = set(weekly_col.distinct("_id"))
+            new_ids = [doc["_id"] for doc in prod_docs if doc["_id"] not in existing_weekly_ids]
+
+            if new_ids:
+                docs_to_transfer = list(prod_col.find({"_id": {"$in": new_ids}}))
+                weekly_col.insert_many(docs_to_transfer)
+                logger.info("Transferred %d new records to weekly collection.", len(docs_to_transfer))
+            else:
+                logger.info("No new records to transfer. Weekly collection is up-to-date.")
+
+        prune_collection(prod_col, MIN_PROD_RECORDS, "prod")
+        prune_collection(weekly_col, MIN_WEEKLY_RECORDS, "weekly")
+        logger.info("Worker sync and prune completed successfully.")
+
+    except Exception:
+        logger.exception("Worker process encountered an unhandled error.")
+        exit_code = 1
+    finally:
+        deliver_run_notifications(log_path=log_file, success=(exit_code == 0))
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(sync_and_prune())


### PR DESCRIPTION
Currently one of our MongoDB cluster is coming to its limit (512MB for free tier). Yet we need one week of data for analysis. This worker's task is simple, working when our customers are falling asleep. It will transfer all the scraped data of today and store it in archive cluster. A fall back solution is that it will keep at least 10 records for prod, and 60 records for archive. Performance? 1s down to ~600ms (Actually I added index to improve the speed). Overall, keeps these two cluster works separately allows upcoming extension of the whole project.