### PR TITLE
Fix: dead, closed sockets due to Cloudflare

### DIFF
--- a/client/src/lib/newsRepository.ts
+++ b/client/src/lib/newsRepository.ts
@@ -32,63 +32,7 @@ async function getClient(): Promise<MongoClient> {
   return cachedClientPromise;
 }
 
-/**
- * Fetch latest snapshot via MongoDB Atlas Data API (HTTPS REST).
- * Best practice for Edge Runtimes (Cloudflare Workers) — zero persistent TCP sockets.
- */
-async function getLatestSnapshotViaDataApi(): Promise<SnapshotDocument | null> {
-  const endpoint = process.env.MONGO_ATLAS_DATA_API_URL;
-  const apiKey = process.env.MONGO_ATLAS_DATA_API_KEY;
-  const clusterName = process.env.MONGO_ATLAS_CLUSTER_NAME ?? "Cluster0";
-  const dbName = process.env.MONGO_DB ?? "rate_pulse";
-  const collectionName = process.env.MONGO_COLLECTION ?? "news-rate-pulse";
-
-  if (!endpoint || !apiKey) {
-    return null;
-  }
-
-  const url = endpoint.endsWith("/")
-    ? `${endpoint}action/findOne`
-    : `${endpoint}/action/findOne`;
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "api-key": apiKey,
-    },
-    body: JSON.stringify({
-      dataSource: clusterName,
-      database: dbName,
-      collection: collectionName,
-      sort: { generated_at: -1 },
-    }),
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(`MongoDB Data API HTTP Error ${response.status}: ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  const doc = data.document;
-
-  if (!doc) {
-    return null;
-  }
-
-  return {
-    ...doc,
-    _id: typeof doc._id === "object" ? doc._id.$oid ?? String(doc._id) : String(doc._id),
-    generated_at: typeof doc.generated_at === "string" ? doc.generated_at : new Date(doc.generated_at).toISOString(),
-  } as SnapshotDocument;
-}
-
 export async function getLatestSnapshot(): Promise<SnapshotDocument | null> {
-  if (process.env.MONGO_ATLAS_DATA_API_URL && process.env.MONGO_ATLAS_DATA_API_KEY) {
-    return getLatestSnapshotViaDataApi();
-  }
-
   const dbName = process.env.MONGO_DB ?? "rate_pulse";
   const collectionName = process.env.MONGO_COLLECTION ?? "news-rate-pulse";
 

--- a/client/src/lib/newsRepository.ts
+++ b/client/src/lib/newsRepository.ts
@@ -19,6 +19,8 @@ async function getClient(): Promise<MongoClient> {
         strict: true,
         deprecationErrors: true,
       },
+      connectTimeoutMS: 5000,
+      socketTimeoutMS: 5000,
     });
 
     cachedClientPromise = client.connect().catch((error) => {
@@ -31,29 +33,40 @@ async function getClient(): Promise<MongoClient> {
 }
 
 export async function getLatestSnapshot(): Promise<SnapshotDocument | null> {
-  const client = await getClient();
   const dbName = process.env.MONGO_DB ?? "rate_pulse";
-  const collectionName =
-    process.env.MONGO_COLLECTION ?? "news-rate-pulse";
+  const collectionName = process.env.MONGO_COLLECTION ?? "news-rate-pulse";
 
-  const doc = await client
-    .db(dbName)
-    .collection(collectionName)
-    .find({})
-    .sort({ generated_at: -1 })
-    .limit(1)
-    .next();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const client = await getClient();
+      const doc = await client
+        .db(dbName)
+        .collection(collectionName)
+        .find({})
+        .sort({ generated_at: -1 })
+        .limit(1)
+        .next();
 
-  if (!doc) {
-    return null;
+      if (!doc) {
+        return null;
+      }
+
+      return {
+        ...doc,
+        _id: doc._id.toString(),
+        generated_at:
+          doc.generated_at instanceof Date
+            ? doc.generated_at.toISOString()
+            : String(doc.generated_at),
+      } as SnapshotDocument;
+    } catch (err: any) {
+      cachedClientPromise = null;
+      if (attempt === 1) {
+        throw err;
+      }
+    }
   }
 
-  return {
-    ...doc,
-    _id: doc._id.toString(),
-    generated_at:
-      doc.generated_at instanceof Date
-        ? doc.generated_at.toISOString()
-        : String(doc.generated_at),
-  } as SnapshotDocument;
+  return null;
 }
+

--- a/client/src/lib/newsRepository.ts
+++ b/client/src/lib/newsRepository.ts
@@ -32,7 +32,63 @@ async function getClient(): Promise<MongoClient> {
   return cachedClientPromise;
 }
 
+/**
+ * Fetch latest snapshot via MongoDB Atlas Data API (HTTPS REST).
+ * Best practice for Edge Runtimes (Cloudflare Workers) — zero persistent TCP sockets.
+ */
+async function getLatestSnapshotViaDataApi(): Promise<SnapshotDocument | null> {
+  const endpoint = process.env.MONGO_ATLAS_DATA_API_URL;
+  const apiKey = process.env.MONGO_ATLAS_DATA_API_KEY;
+  const clusterName = process.env.MONGO_ATLAS_CLUSTER_NAME ?? "Cluster0";
+  const dbName = process.env.MONGO_DB ?? "rate_pulse";
+  const collectionName = process.env.MONGO_COLLECTION ?? "news-rate-pulse";
+
+  if (!endpoint || !apiKey) {
+    return null;
+  }
+
+  const url = endpoint.endsWith("/")
+    ? `${endpoint}action/findOne`
+    : `${endpoint}/action/findOne`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "api-key": apiKey,
+    },
+    body: JSON.stringify({
+      dataSource: clusterName,
+      database: dbName,
+      collection: collectionName,
+      sort: { generated_at: -1 },
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`MongoDB Data API HTTP Error ${response.status}: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  const doc = data.document;
+
+  if (!doc) {
+    return null;
+  }
+
+  return {
+    ...doc,
+    _id: typeof doc._id === "object" ? doc._id.$oid ?? String(doc._id) : String(doc._id),
+    generated_at: typeof doc.generated_at === "string" ? doc.generated_at : new Date(doc.generated_at).toISOString(),
+  } as SnapshotDocument;
+}
+
 export async function getLatestSnapshot(): Promise<SnapshotDocument | null> {
+  if (process.env.MONGO_ATLAS_DATA_API_URL && process.env.MONGO_ATLAS_DATA_API_KEY) {
+    return getLatestSnapshotViaDataApi();
+  }
+
   const dbName = process.env.MONGO_DB ?? "rate_pulse";
   const collectionName = process.env.MONGO_COLLECTION ?? "news-rate-pulse";
 


### PR DESCRIPTION
Cloudflare Worker is a serverless edge runtimes (V8 Isolates), so it freezes and suspends background tasks between HTTP requests, breaking statefule TCP connection. Currently, in `client/src/lib/newsRepository.ts` established a TCP connection between MongoDB and client to reduce the number of time we reconnect with MongoDB. However, this cause the problem when Cloudflare Worker forces to close the connection, causing `getClient()` returns cached client with dead, closed sockets. 

The solution is that we will add TTL for MongoDB to let it terminate old connection after 5s, and let React silently handle the connection in the background -> users won't be affected